### PR TITLE
Restore livecodebench_util.py from commit e893355

### DIFF
--- a/llm_evaluation/livecodebench_util.py
+++ b/llm_evaluation/livecodebench_util.py
@@ -488,44 +488,20 @@ def reliability_guard(maximum_memory_bytes: Optional[int] = None):
 
     import builtins
 
-    from typing import Any, cast
-
-    builtins.exit = cast(Any, None)
-    builtins.quit = cast(Any, None)
+    from typing import Any
 
     # Prepare Any-typed aliases to avoid mypy assignment errors
+    builtins_mod: Any = builtins
     os_mod: Any = os
+    shutil_mod: Any = shutil
     subprocess_mod: Any = subprocess
+    modules_any: Any = sys.modules
 
     os.environ["OMP_NUM_THREADS"] = "1"
 
-    os.kill = cast(Any, None)
-    os.system = cast(Any, None)
-    os.putenv = cast(Any, None)
-    os.remove = cast(Any, None)
-    os.removedirs = cast(Any, None)
-    os.rmdir = cast(Any, None)
-    os.fchdir = cast(Any, None)
-    os.setuid = cast(Any, None)
-    os.fork = cast(Any, None)
-    os.forkpty = cast(Any, None)
-    os.killpg = cast(Any, None)
-    os.rename = cast(Any, None)
-    os.renames = cast(Any, None)
-    os.truncate = cast(Any, None)
-    os.replace = cast(Any, None)
-    os.unlink = cast(Any, None)
-    os.fchmod = cast(Any, None)
-    os.fchown = cast(Any, None)
-    os.chmod = cast(Any, None)
-    os.chown = cast(Any, None)
-    os.chroot = cast(Any, None)
-    os.fchdir = cast(Any, None)
-    os.lchflags = cast(Any, None)  # type: ignore[attr-defined]
-    os.lchmod = cast(Any, None)  # type: ignore[attr-defined]
-    os.lchown = cast(Any, None)
-    os.getcwd = cast(Any, None)
-    os.chdir = cast(Any, None)
+    # Disable selected builtins
+    setattr(builtins_mod, "exit", None)
+    setattr(builtins_mod, "quit", None)
 
     # Disable destructive os functions (guard where platform-specific)
     for name in [
@@ -561,22 +537,19 @@ def reliability_guard(maximum_memory_bytes: Optional[int] = None):
         except Exception:
             pass
 
-    shutil.rmtree = cast(Any, None)
-    shutil.move = cast(Any, None)
-    shutil.chown = cast(Any, None)
+    # Disable dangerous shutil functions
+    for name in ["rmtree", "move", "chown"]:
+        try:
+            setattr(shutil_mod, name, None)
+        except Exception:
+            pass
 
     # Disable subprocess.Popen
     setattr(subprocess_mod, "Popen", None)
 
-    setattr(subprocess, "Popen", cast(Any, None))
-
-    # __builtins__["help"] = None   # this line is commented out as it results into error
-
-    sys.modules["ipdb"] = None  # type: ignore[assignment]
-    sys.modules["joblib"] = None  # type: ignore[assignment]
-    sys.modules["resource"] = None  # type: ignore[assignment]
-    sys.modules["psutil"] = None  # type: ignore[assignment]
-    sys.modules["tkinter"] = None  # type: ignore[assignment]
+    # Hide selected modules
+    for name in ["ipdb", "joblib", "resource", "psutil", "tkinter"]:
+        modules_any[name] = None
 
 
 def save_original_references():
@@ -642,7 +615,7 @@ def restore_original_references():
         setattr(shutil, func_name, original_func)
 
     # Restore 'subprocess' functions
-    setattr(subprocess, "Popen", originals["subprocess"]["Popen"])
+    setattr(subprocess, "Popen", originals["subprocess"]["Popen"])  # type: ignore[misc]
 
     # Restore sys modules
     for module_name, original_module in originals["sys_modules"].items():


### PR DESCRIPTION
We restore the livecodebench_util.py from commit e893355. It was not reflected in the previous version, and this is a fix to that. 