### PR TITLE
[Chore] Ignore .json format in router_inference

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     - id: trailing-whitespace
       args: [--markdown-linebreak-ext=md]
     - id: end-of-file-fixer
+      exclude: '^router_inference/(predictions|config)/.*\.json$'
     - id: check-ast
     - id: check-yaml
       args: [--allow-multiple-documents]


### PR DESCRIPTION
Router owner's submitted router config and predictions json files could bypass the end of file checker. We don't want to touch their config and prediction files.