### PR TITLE
Fix optimality metric conditioning to match paper (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ For more details, please see our [website](https://routeworks.github.io/leaderbo
 
 | Rank | Router | Affiliation | Acc-Cost Arena | Accuracy | Cost/1K Queries | Optimal Selection | Optimal Cost | Optimal Accuracy | Latency | Robustness |
 |------|--------------------|-----------------------------|--------|----------|---------|-----------------|--------------|----------------|---------|------------|
-| 🥇 | [Weave Router](https://workweave.dev)&nbsp;[[Code]](https://github.com/workweave/router) | 🎓&nbsp;Weave | 74.61 | 78.43 | $0.92 | 1.38 | 12.27 | 100.00 | — | 79.05 |
-| 🥈 | [R2-Router](https://arxiv.org/abs/2602.02823/) | 🎓&nbsp;UCF | 71.60 | 71.23 | $0.06 | 32.38 | 74.16 | 100.00 | — | 45.71 |
-| 🥉 | [Auto Router]() |  | 70.05 | 70.17 | $0.12 | 43.77 | 42.29 | 100.00 | — | 49.52 |
-| 4 | [vLLM‑SR](https://vllm-semantic-router.com/)&nbsp;[[Code]](https://github.com/vllm-project/semantic-router)&nbsp;[[HF]](https://huggingface.co/llm-semantic-router) | 🎓&nbsp;vLLM SR Team | 67.23 | 66.53 | $0.06 | 94.10 | 90.12 | 100.00 | — | 90.95 |
+| 🥇 | [Weave Router](https://workweave.dev)&nbsp;[[Code]](https://github.com/workweave/router) | 🎓&nbsp;Weave | 74.61 | 78.43 | $0.92 | 1.27 | 12.10 | 89.56 | — | 79.05 |
+| 🥈 | [R2-Router](https://arxiv.org/abs/2602.02823/) | 🎓&nbsp;UCF | 71.60 | 71.23 | $0.06 | 24.51 | 48.70 | 99.85 | — | 45.71 |
+| 🥉 | [Auto Router]() |  | 70.05 | 70.17 | $0.12 | 37.58 | 40.02 | 86.04 | — | 49.52 |
+| 4 | [vLLM‑SR](https://vllm-semantic-router.com/)&nbsp;[[Code]](https://github.com/vllm-project/semantic-router)&nbsp;[[HF]](https://huggingface.co/llm-semantic-router) | 🎓&nbsp;vLLM SR Team | 67.23 | 66.53 | $0.06 | 84.66 | 90.71 | 89.24 | — | 90.95 |
 | 5 | [MIRT‑BERT](https://arxiv.org/pdf/2506.01048)&nbsp;[[Code]](https://github.com/Mercidaiha/IRT-Router) | 🎓&nbsp;USTC | 66.89 | 66.88 | $0.15 | 3.44 | 19.62 | 78.18 | 27.03 | 61.19 |
 | 6 | [Azure-Model-Router](https://ai.azure.com/catalog/models/model-router)&nbsp;[[Web]](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router) | 💼&nbsp;Microsoft | 66.66 | 68.09 | $0.54 | 22.52 | 46.32 | 81.96 | — | 54.07 |
 | 7 | [NIRT‑BERT](https://arxiv.org/pdf/2506.01048)&nbsp;[[Code]](https://github.com/Mercidaiha/IRT-Router) | 🎓&nbsp;USTC | 66.12 | 66.34 | $0.21 | 3.83 | 14.04 | 77.88 | 10.42 | 49.29 |

--- a/llm_evaluation/run.py
+++ b/llm_evaluation/run.py
@@ -802,10 +802,6 @@ def compute_optimality_from_predictions(
 
             optimal_model_name, optimal_accuracy, optimal_cost = optimal_result
 
-            # Skip if router didn't achieve perfect accuracy
-            if router_accuracy < 1.0:
-                continue
-
             queries_with_optimal_data += 1
 
             # Convert router model name to universal name for comparison (same as leaderboard)
@@ -825,17 +821,20 @@ def compute_optimality_from_predictions(
             except Exception:
                 optimal_model_universal = optimal_model_name
 
-            # Check if router selected the optimal model
-            if router_model_universal == optimal_model_universal:
+            # Opt.Sel: router answered correctly AND picked the cheapest-correct model
+            if (
+                router_accuracy >= 1.0
+                and router_model_universal == optimal_model_universal
+            ):
                 optimal_selections += 1
 
-            # Accumulate accuracies (both should be >= 1.0 at this point)
-            if optimal_accuracy is not None:
-                total_optimal_accuracy += optimal_accuracy
-                total_router_accuracy += router_accuracy
+            # Opt.Acc: router accuracy / oracle accuracy, summed over the conditioned set
+            total_optimal_accuracy += optimal_accuracy
+            total_router_accuracy += router_accuracy
 
-            # Accumulate costs (only for queries where both achieved perfect accuracy)
-            if optimal_cost != float("inf") and router_cost > 0:
+            # Opt.Cost: restrict to queries where the router answered correctly,
+            # so cheap-but-wrong selections can't push the ratio above 1.0.
+            if router_accuracy >= 1.0:
                 total_optimal_cost += optimal_cost
                 total_router_cost += router_cost
 


### PR DESCRIPTION
## Summary

Fixes #95.

@namitha-sqwish flagged that `compute_optimality_from_predictions`
contained an `if router_accuracy < 1.0: continue` skip that dropped
every query where the router answered incorrectly. As they noted,
this contradicts the paper's definition of Opt.Acc, and we provide a fix in this PR.

## Root cause

The blanket skip caused two compounding problems:

1. **Opt.Acc reduced to ~1.0 by construction.** Both accumulators only
   counted router-correct rows where the oracle was also correct
   (both `acc >= 1.0`), so the ratio became `n / n ≈ 1.0`. Every
   workflow-evaluated router in the leaderboard reported
   `Optimal Accuracy = 100.00` for this reason.
2. **Opt.Sel and Opt.Cost denominators silently shrank.** Router-wrong
   queries were excluded from the denominator entirely instead of
   contributing a "not optimal" / "not router-correct" outcome.

## Fix

`llm_evaluation/run.py`: remove the early-continue and apply per-metric
conditioning matching the paper:

| Metric | Numerator | Denominator |
|---|---|---|
| **Opt.Sel** | router answered correctly **AND** picked the cheapest-correct model | queries where the oracle exists (≥1 pool model is correct) |
| **Opt.Acc** | Σ `router_accuracy` | Σ `oracle_accuracy` over the same set |
| **Opt.Cost** | Σ `oracle_cost` | Σ `router_cost`, restricted to router-correct queries so cheap-but-wrong selections can't push the ratio above 1 |

## Leaderboard impact

Updated the 4 routers that were submitted through the optimality
workflow (predictions carry `for_optimality` entries). Other rows are
unchanged: paper-era routers stay as-is per project convention.
