### PR TITLE
Free up disk space before dataset prep in /evaluate workflow

### DIFF
--- a/.github/workflows/pr-evaluation.yml
+++ b/.github/workflows/pr-evaluation.yml
@@ -187,6 +187,21 @@ jobs:
           echo "Detected router submission: ${{ steps.detect.outputs.router }}"
           echo "Detected split: ${{ steps.detect.outputs.split }}"
 
+      - name: Free up disk space on the runner
+        if: ${{ steps.detect.outputs.router != '' }}
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # Reclaims ~20GB by removing preinstalled tools the eval doesn't use.
+          # Keep tool-cache so actions/setup-python below stays fast.
+          # Leave swap-storage alone — the Enable Swap Space step manages it.
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
       - name: Set up Python
         if: ${{ steps.detect.outputs.router != '' }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
The PR-evaluation workflow runs on ubuntu-latest (~14GB free disk). Larger router submissions like Azure-Model-Router (#98) exceed that ceiling during prep_datasets.py, which downloads three RouterArena splits plus lighteval/code_generation_lite into the HF cache and a save_to_disk copy, alongside the .venv and dual repo checkouts.

Add a jlumbroso/free-disk-space@main step before the heavy work, reclaiming ~20GB by removing the preinstalled Android SDK, .NET, Haskell, large APT packages, and Docker images. Keep the Python tool-cache (actions/setup-python uses it) and leave swap-storage to the existing Enable Swap Space step.