### PR TITLE
docs(readme): update leaderboard with Weave Router v0.62 (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ For more details, please see our [website](https://routeworks.github.io/leaderbo
 
 | Rank | Router | Affiliation | Acc-Cost Arena | Accuracy | Cost/1K Queries | Optimal Selection | Optimal Cost | Optimal Accuracy | Latency | Robustness |
 |------|--------------------|-----------------------------|--------|----------|---------|-----------------|--------------|----------------|---------|------------|
-| 🥇 | [Sqwish Router]() |  | 75.27 | 76.40 | $0.18 | 7.41 | 25.10 | 90.47 | — | 100.00 |
-| 🥈 | [Weave Router](https://workweave.dev)&nbsp;[[Code]](https://github.com/workweave/router) | 🎓&nbsp;Weave | 74.61 | 78.43 | $0.92 | 1.27 | 12.10 | 89.56 | — | 79.05 |
+| 🥇 | [Weave Router](https://workweave.dev)&nbsp;[[Code]](https://github.com/workweave/router) | 🎓&nbsp;Weave | 76.09 | 79.32 | $0.61 | 5.60 | 17.19 | 89.21 | — | 79.76 |
+| 🥈 | [Sqwish Router]() |  | 75.27 | 76.40 | $0.18 | 7.41 | 25.10 | 90.47 | — | 100.00 |
 | 🥉 | [R2-Router](https://arxiv.org/abs/2602.02823/) | 🎓&nbsp;UCF | 71.60 | 71.23 | $0.06 | 24.51 | 48.70 | 99.85 | — | 45.71 |
 | 4 | [Auto Router]() |  | 70.05 | 70.17 | $0.12 | 37.58 | 40.02 | 86.04 | — | 49.52 |
 | 5 | [vLLM‑SR](https://vllm-semantic-router.com/)&nbsp;[[Code]](https://github.com/vllm-project/semantic-router)&nbsp;[[HF]](https://huggingface.co/llm-semantic-router) | 🎓&nbsp;vLLM SR Team | 67.23 | 66.53 | $0.06 | 84.66 | 90.71 | 89.24 | — | 90.95 |


### PR DESCRIPTION
Update the leaderboard table with the Weave Router v0.62 results from #102.

Submission PR: #102