### PR TITLE
Add no-training policy callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ RouterArena bridges this gap by providing an open evaluation platform and benchm
 
 *We aim for RouterArena to serve as a foundation for the community to evaluate, understand, and advance LLM routing systems.*
 
+> [!IMPORTANT]
+> **RouterArena is an evaluation-only dataset.** Submissions that train, fit, or tune any router component on RouterArena data (including the label files) will be rejected, and any accepted submission found in violation will be withdrawn.
+
 # Current Leaderboard
 
 For more details, please see our [website](https://routeworks.github.io/leaderboard) and [blog](https://huggingface.co/blog/JerryPotter/who-routes-the-routers).


### PR DESCRIPTION
State explicitly that RouterArena is an evaluation-only dataset and that submissions which trained, fit, or tuned any router component on RouterArena data will be rejected (and accepted submissions found in violation will be withdrawn). The policy was implicit before, leaving room for good-faith disagreement on what counts as training; this makes the rule discoverable up front.