### PR TITLE
[Fix] count failed/empty generations as wrong instead of droppin them. 

### DIFF
--- a/.github/workflows/pr-evaluation.yml
+++ b/.github/workflows/pr-evaluation.yml
@@ -293,9 +293,22 @@ jobs:
             comment += `| **Avg Cost per Query** | $${metrics.avg_cost_per_query.toFixed(6)} |\n`;
             comment += `| **Avg Cost per 1K Queries** | $${metrics.avg_cost_per_1000.toFixed(4)} |\n`;
             comment += `| **Number of Queries** | ${metrics.num_queries} |\n`;
+            const abnormalCount = metrics.abnormal_count;
+            if (abnormalCount !== undefined) {
+              comment += `| **Abnormal Entries** | ${abnormalCount} |\n`;
+            }
             const robustnessScore = metrics.robustness_score;
             const robustnessCell = robustnessScore !== undefined ? robustnessScore.toFixed(4) : 'N/A';
             comment += `| **Robustness Score** | ${robustnessCell} |\n`;
+
+            // Warn the author if some queries had no valid generation (scored as 0)
+            if (abnormalCount && abnormalCount > 0) {
+              const pct = ((abnormalCount / metrics.num_queries) * 100).toFixed(1);
+              comment += `\n> ⚠️ **${abnormalCount} of ${metrics.num_queries} queries (${pct}%) had no valid generation** `;
+              comment += `(inference failed / empty answer) and were scored as **incorrect (0)**. `;
+              comment += `These queries still count toward the denominator, so accuracy and cost reflect the full query set. `;
+              comment += `Please regenerate predictions for these queries and resubmit for a complete evaluation.\n`;
+            }
 
             // Add optimality scores if available
             if (metrics.optimality) {

--- a/automation/process_pr_submission.py
+++ b/automation/process_pr_submission.py
@@ -254,11 +254,22 @@ def compute_scores(prediction_file: Path) -> dict[str, float]:
     # Filter to regular predictions only (exclude optimality entries)
     regular_predictions = [p for p in predictions if not p.get("for_optimality", False)]
 
-    accuracies = [
-        entry["accuracy"]
-        for entry in regular_predictions
-        if entry.get("accuracy") is not None
-    ]
+    # Every regular query contributes to the accuracy denominator. Entries with no
+    # valid generation (success=False / missing / empty) are scored as 0, not dropped,
+    # so accuracy cannot be inflated over a self-selected answered subset.
+    accuracies = []
+    abnormal_count = 0
+    for entry in regular_predictions:
+        generated_result = entry.get("generated_result")
+        has_valid_generation = isinstance(
+            generated_result, dict
+        ) and generated_result.get("success", False)
+        accuracy = entry.get("accuracy")
+        if not has_valid_generation or accuracy is None:
+            accuracy = 0.0
+            abnormal_count += 1
+        accuracies.append(accuracy)
+
     costs = [
         entry["cost"]
         for entry in regular_predictions
@@ -280,6 +291,7 @@ def compute_scores(prediction_file: Path) -> dict[str, float]:
         "avg_cost_per_query": avg_cost_per_query,
         "avg_cost_per_1000": avg_cost_per_1000,
         "arena_score": arena_score,
+        "abnormal_count": abnormal_count,
     }
 
 

--- a/automation/process_pr_submission.py
+++ b/automation/process_pr_submission.py
@@ -270,13 +270,16 @@ def compute_scores(prediction_file: Path) -> dict[str, float]:
         accuracy = entry.get("accuracy")
         # Accept accuracy only if it is a real number (reject bool, since
         # isinstance(True, int) is True, and strings that would break sum()).
-        valid_accuracy = isinstance(accuracy, (int, float)) and not isinstance(
-            accuracy, bool
-        )
-        if not has_valid_generation or not valid_accuracy:
+        if (
+            has_valid_generation
+            and isinstance(accuracy, (int, float))
+            and not isinstance(accuracy, bool)
+        ):
+            accuracies.append(float(accuracy))
+        else:
             accuracy = 0.0
             abnormal_count += 1
-        accuracies.append(accuracy)
+            accuracies.append(0.0)
 
     costs = [
         entry["cost"]

--- a/automation/process_pr_submission.py
+++ b/automation/process_pr_submission.py
@@ -261,11 +261,19 @@ def compute_scores(prediction_file: Path) -> dict[str, float]:
     abnormal_count = 0
     for entry in regular_predictions:
         generated_result = entry.get("generated_result")
-        has_valid_generation = isinstance(
-            generated_result, dict
-        ) and generated_result.get("success", False)
+        # Untrusted contributor input: require success to be exactly True (a
+        # truthy string like "False" must not pass).
+        has_valid_generation = (
+            isinstance(generated_result, dict)
+            and generated_result.get("success") is True
+        )
         accuracy = entry.get("accuracy")
-        if not has_valid_generation or accuracy is None:
+        # Accept accuracy only if it is a real number (reject bool, since
+        # isinstance(True, int) is True, and strings that would break sum()).
+        valid_accuracy = isinstance(accuracy, (int, float)) and not isinstance(
+            accuracy, bool
+        )
+        if not has_valid_generation or not valid_accuracy:
             accuracy = 0.0
             abnormal_count += 1
         accuracies.append(accuracy)

--- a/llm_evaluation/run.py
+++ b/llm_evaluation/run.py
@@ -956,16 +956,16 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
         accuracy = prediction.get("accuracy")
         # Accept accuracy only if it is a real number (reject bool, since
         # isinstance(True, int) is True, and strings that would break sum()).
-        valid_accuracy = isinstance(accuracy, (int, float)) and not isinstance(
-            accuracy, bool
-        )
-
-        if not has_valid_generation or not valid_accuracy:
+        if (
+            has_valid_generation
+            and isinstance(accuracy, (int, float))
+            and not isinstance(accuracy, bool)
+        ):
+            accuracies.append(float(accuracy))
+        else:
             # No successful generation (or missing/invalid score): count as wrong.
-            accuracy = 0.0
+            accuracies.append(0.0)
             abnormal_count += 1
-
-        accuracies.append(accuracy)
 
         cost = prediction.get("cost")
         if cost is not None and cost > 0:

--- a/llm_evaluation/run.py
+++ b/llm_evaluation/run.py
@@ -932,15 +932,32 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
     regular_predictions = [p for p in predictions if not p.get("for_optimality", False)]
     optimality_predictions = [p for p in predictions if p.get("for_optimality", False)]
 
-    # Extract accuracy and cost ONLY from regular predictions for RouterArena score
+    # Extract accuracy and cost ONLY from regular predictions for RouterArena score.
+    #
+    # IMPORTANT: every regular query must contribute to the accuracy denominator.
+    # Entries with no valid generation (inference failed / success=False / empty
+    # generated_answer) are NOT dropped — they are scored as 0 (wrong) and counted
+    # via ``abnormal_count``. Silently dropping them would let a submission inflate
+    # accuracy (averaged over a self-selected subset) and dilute cost (summed over
+    # the answered subset but divided by the full query count).
     accuracies = []
     costs = []
     valid_cost_count = 0
+    abnormal_count = 0
 
     for prediction in regular_predictions:
+        generated_result = prediction.get("generated_result")
+        has_valid_generation = isinstance(generated_result, dict) and generated_result.get(
+            "success", False
+        )
         accuracy = prediction.get("accuracy")
-        if accuracy is not None:
-            accuracies.append(accuracy)
+
+        if not has_valid_generation or accuracy is None:
+            # No successful generation (or somehow unscored): count as wrong.
+            accuracy = 0.0
+            abnormal_count += 1
+
+        accuracies.append(accuracy)
 
         cost = prediction.get("cost")
         if cost is not None and cost > 0:
@@ -948,15 +965,10 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
             valid_cost_count += 1
 
     # Check if any entries were evaluated
-    if not accuracies and not costs:
+    if not regular_predictions:
         raise ValueError(
-            "No entries were evaluated. All prediction entries are missing 'generated_result' fields. "
+            "No regular (non-optimality) entries found. "
             "Please run llm_inference/run.py first to generate model outputs before evaluation."
-        )
-
-    if not accuracies:
-        raise ValueError(
-            "No entries have accuracy values. Cannot compute RouterArena score without accuracy data."
         )
 
     if not costs:
@@ -964,7 +976,7 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
             "No entries have valid cost values. Cannot compute RouterArena score without cost data."
         )
 
-    # Compute average accuracy
+    # Compute average accuracy over ALL regular queries (abnormal entries count as 0)
     avg_accuracy = sum(accuracies) / len(accuracies) if accuracies else 0.0
 
     # Compute total cost (sum of all costs)
@@ -989,6 +1001,9 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
         )
     logger.info(f"Queries with Accuracy: {len(accuracies)}")
     logger.info(f"Queries with Valid Cost: {valid_cost_count}")
+    logger.info(
+        f"Abnormal Entries (no valid generation, scored as 0): {abnormal_count}"
+    )
     logger.info(f"Average Accuracy: {avg_accuracy:.4f}")
     logger.info(f"Total Cost: ${total_cost:.6f}")
     if num_queries > 0:
@@ -1050,6 +1065,7 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
         "avg_cost_per_query": total_cost / num_queries if num_queries > 0 else 0.0,
         "avg_cost_per_1000": avg_cost_per_1000,
         "num_queries": num_queries,
+        "abnormal_count": abnormal_count,
     }
 
     # Add optimality scores if available (reuse previously computed result)

--- a/llm_evaluation/run.py
+++ b/llm_evaluation/run.py
@@ -947,13 +947,21 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
 
     for prediction in regular_predictions:
         generated_result = prediction.get("generated_result")
-        has_valid_generation = isinstance(generated_result, dict) and generated_result.get(
-            "success", False
+        # Prediction files are untrusted contributor input. Require success to be
+        # exactly True (a truthy string like "False" must not pass).
+        has_valid_generation = (
+            isinstance(generated_result, dict)
+            and generated_result.get("success") is True
         )
         accuracy = prediction.get("accuracy")
+        # Accept accuracy only if it is a real number (reject bool, since
+        # isinstance(True, int) is True, and strings that would break sum()).
+        valid_accuracy = isinstance(accuracy, (int, float)) and not isinstance(
+            accuracy, bool
+        )
 
-        if not has_valid_generation or accuracy is None:
-            # No successful generation (or somehow unscored): count as wrong.
+        if not has_valid_generation or not valid_accuracy:
+            # No successful generation (or missing/invalid score): count as wrong.
             accuracy = 0.0
             abnormal_count += 1
 


### PR DESCRIPTION
The router evaluation averaged accuracy only over entries that produced a valid generation, while dividing total cost by the full regular-query count. A submission could exploit this asymmetry by marking queries it did not want scored as success=false (empty generation): those entries were silently dropped from the accuracy denominator (inflating accuracy over a self-selected subset) yet the cost was still spread across all queries (diluting cost/1K). On one submission this lifted the arena score from ~0.22 to 0.76.

Now every regular query contributes to the accuracy denominator: entries with no valid generation (success=false / missing / empty) are scored as 0 and tallied as `abnormal_count`. The count is logged, written to metrics.json, and surfaced in the PR evaluation comment with a warning so authors can regenerate the missing predictions and resubmit.

Routers that answered every query are unaffected (verified byte-identical scores across all currently-accepted leaderboard routers).

- llm_evaluation/run.py: compute_router_metrics counts failed/None as 0 + abnormal_count
- automation/process_pr_submission.py: same logic in compute_scores (defensive)
- .github/workflows/pr-evaluation.yml: show Abnormal Entries row + warning note