### PR TITLE
Update OrcaRouter-Adaptive leaderboard entry: repo link, affiliation, and reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For more details, please see our [website](https://routeworks.github.io/leaderbo
 | 🥈 | [AgentForge Router]() | 👤&nbsp;[@YangY-Z](https://github.com/YangY-Z) | 74.13 | 74.72 | $0.13 | 17.84 | 52.47 | 98.68 | — | 40.48 |
 | 🥉 | [Nadir Router](https://github.com/NadirRouter/NadirClaw) | 🎓&nbsp;NadirRouter | 73.33 | 74.87 | $0.29 | — | — | — | — | 25.48 |
 | 4 | [Weave Router](https://workweave.ai) | 🎓&nbsp;Weave | 72.82 | 76.32 | $0.94 | — | — | — | — | 100.00 |
-| 5 | [OrcaRouter-Adaptive](https://www.orcarouter.ai/) | 👤&nbsp;[@ZhenghuaBao](https://github.com/ZhenghuaBao) | 72.08 | 75.54 | $1.00 | — | — | — | — | 22.62 |
+| 5 | [OrcaRouter‑Adaptive](https://www.orcarouter.ai/)&nbsp;[[Code]](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite)&nbsp;[[Paper]](https://arxiv.org/abs/2605.30736)&nbsp;[[X]](https://x.com/orcarouter) | 🎓&nbsp;Continuum&nbsp;AI | 72.08 | 75.54 | $1.00 | — | — | — | — | 22.62 |
 | 6 | [Azure-Model-Router](https://ai.azure.com/catalog/models/model-router)&nbsp;[[Web]](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router) | 💼&nbsp;Microsoft | 71.87 | 72.82 | $0.22 | — | — | — | — | 71.43 |
 | 7 | [R2-Router](https://arxiv.org/abs/2602.02823/) | 🎓&nbsp;UCF | 71.60 | 71.23 | $0.06 | 24.51 | 48.70 | 99.85 | — | 45.71 |
 | 8 | [Auto Router]() | 👤&nbsp;[@cxf2015](https://github.com/cxf2015) | 70.05 | 70.17 | $0.12 | 37.58 | 40.02 | 86.04 | — | 49.52 |


### PR DESCRIPTION
## Summary
This PR updates the metadata for the **OrcaRouter-Adaptive** entry on the leaderboard. The changes are limited to the README leaderboard table — no config, prediction, or result files are modified, and no metrics change. As the author of this submission, I'm updating the entry to reflect its current home and add reference links.

## Motivation
The OrcaRouter-Adaptive router is now developed and maintained under **Continuum AI** rather than as a personal project. This PR brings the leaderboard entry in line with that: it points to the canonical repository, updates the affiliation, and adds the paper and project social links so readers can find the relevant resources directly from the table.

## Changes
All changes are to the single row in the README leaderboard table.

**Name link (unchanged):**
- `OrcaRouter-Adaptive` → `https://www.orcarouter.ai/`

**Affiliation:**
- Before: individual contributor (`👤 @ZhenghuaBao`)
- After: `🎓 Continuum AI`

**Reference links added (in order after the name):**
- `[[GitHub]]` → `https://github.com/Continuum-AI-Corp/OrcaRouter-Lite`
- `[[Paper]]` → `https://arxiv.org/abs/2605.30736`
- `[[X]]` → `https://x.com/orcarouter`


## Metrics
No change. Accuracy (75.54), Acc-Cost Arena (72.08), Cost/1K ($1.00), and robustness (22.62) are all identical to the current leaderboard. This is a documentation-only update.

## Evaluation
Because no predictions or results changed, this PR does **not** require a re-run of the evaluation workflow. Please let me know if you'd still prefer me to call `/evaluate` for consistency with your process, or if you can merge as a docs-only change.

## Checklist
- [x] README table row updated
- [x] All links verified resolving
- [x] No changes to config / prediction / result files
- [x] Affiliation icon follows legend (🎓 = open-source)