### PR TITLE
Update vLLM-SR RouterArena submission

### DIFF
--- a/router_inference/config/vllm-sr.json
+++ b/router_inference/config/vllm-sr.json
@@ -1,30 +1,18 @@
 {
   "pipeline_params": {
-      "router_name": "vllm-sr",
-      "router_cls_name": "VLLMSR",
-      "models": [
-          "gpt-4o-mini",
-          "claude-3-haiku-20240307",
-          "gemini-2.0-flash-001"
-      ],
-      "router_endpoint": "http://localhost:8080",
-      "base_url": "http://localhost:8080",
-      "default_model": "gpt-4o-mini",
-      "category_model_mapping": {
-          "biology_decision": "claude-3-haiku-20240307",
-          "business_decision": "gemini-2.0-flash-001",
-          "chemistry_decision": "gemini-2.0-flash-001",
-          "economics_decision": "gpt-4o-mini",
-          "engineering_decision": "gemini-2.0-flash-001",
-          "general_decision": "claude-3-haiku-20240307",
-          "health_decision": "claude-3-haiku-20240307",
-          "history_decision": "gpt-4o-mini",
-          "law_decision": "gemini-2.0-flash-001",
-          "math_decision": "gemini-2.0-flash-001",
-          "other": "gemini-2.0-flash-001",
-          "philosophy_decision": "gpt-4o-mini",
-          "physics_decision": "gemini-2.0-flash-001",
-          "psychology_decision": "gemini-2.0-flash-001"
-      }
+    "router_name": "vllm-sr",
+    "router_cls_name": "VLLMSR",
+    "models": [
+      "google/gemini-3.1-flash-lite",
+      "gemini-2.5-flash",
+      "deepseek/deepseek-v4-flash",
+      "grok-4-1-fast-reasoning",
+      "qwen/qwen3-235b-a22b-2507",
+      "qwen/qwen3-next-80b-a3b-instruct",
+      "Qwen/Qwen3-Coder-Next",
+      "deepseek-reasoner"
+    ],
+    "default_model": "google/gemini-3.1-flash-lite",
+    "description": "vLLM Semantic Router submission using deterministic semantic, structural, domain-aware, and cost-aware routing over a compact model pool."
   }
 }

--- a/router_inference/predictions/vllm-sr-robustness.json
+++ b/router_inference/predictions/vllm-sr-robustness.json
@@ -2,7 +2,7 @@
   {
     "global index": "AIME_112",
     "prompt": "Deliver a thorough resolution of the ensuing arithmetic puzzle in a sequential manner.\n\nScenario: Absent\n\nInquiry: With an inexhaustible stockpile of coins valued at 1-cent, 10-cents, and 25-cents, Silas is on a quest to assemble a coin collection summing to $ N $ cents, where $ N $ is a positive integer figure. He employs what's known as the **greedy method**, opting each time for the highest denomination that doesn't push his collection's sum beyond $ N $. Illustratively, for 42 cents, Silas opts for a 25-cent coin, followed by a 10-cent, and then seven 1-cent coins. However, this assortment of nine coins surpasses the required count to reach 42 cents; in fact, selecting four 10-cent coins and two 1-cent coins sums up the same with only six coins.\n\nTypically, the greedy method prevails for a specific $ N $ if no alternate assemblage of 1-cent, 10-cent, and 25-cent coins sums to $ N $ cents using a smaller number of coins than the greedy method's set. Ascertain the quantity of values for $ N $ spanning from 1 to 1000 inclusive where the greedy method is successful.\n\nSubmit your conclusive response in the format \\boxed{{}}, with the precise mathematical expression or numeral encased within the braces. For instance: \\boxed{{42}}. Ensure your elucidation is explicit, succinct, and confined to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -11,7 +11,7 @@
   {
     "global index": "AIME_58",
     "prompt": "Kindly tackle the subsequent arithmetic challenge through a detailed, progressive approach.\n\nScenario: Absent\n\nInquiry: Define \\(\\omega = \\cos\\left(\\frac{2\\pi}{7}\\right) + i\\sin\\left(\\frac{2\\pi}{7}\\right)\\), with \\(i\\) representing \\(\\sqrt{-1}\\). Determine the numerical outcome of the expression \\(\\prod_{k=0}^{6} \\left(\\omega^{3k} + \\omega^k + 1\\right)\\).\n\nExpress your conclusive result in the \\boxed{{}} format, ensuring the brackets enclose the precise mathematical figure or formulation. For instance: \\boxed{{42}}. Maintain your elucidation straightforward, succinct, and confined to a trio of statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -20,7 +20,7 @@
   {
     "global index": "ArcMMLU_12",
     "prompt": "Carefully examine the subsequent multiple-choice queries and select the option that most plausibly represents the accurate response from those provided.\n\nContext: None\n\nInquiry: Which data transmission protocol ensures dependable communication despite errors in bits and lost packets? \n\nSelections: \nA. rdt1.0\nB. rdt2.0\nC. rdt3.0\nD. rdt2.1\n\nIndicate the right letter selection in \\boxed{X}, with X being the appropriate letter. Limit any clarification or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -29,7 +29,7 @@
   {
     "global index": "ArcMMLU_123",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and determine the most probable accurate response from the listed alternatives.\n\nScenario: None\n\nInquiry: Which entity released the periodical titled International Classification?  ( )\n\nChoices:\nA. IFLA  \nB. UNESCO  \nC. ISKO  \nD. ALA  \n\nIndicate the right selection letter in \\boxed{X}, where X stands for the appropriate letter. Restrict the explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -38,7 +38,7 @@
   {
     "global index": "ArcMMLU_16",
     "prompt": "Thoroughly examine the subsequent set of multiple-choice queries and select the option that most plausibly represents the accurate answer from those provided.\n\nSituation: None\n\nInquiry: Which statement regarding the SR protocol is inaccurate? ( )\n\nSelections: \nA. The receiver issues an individual acknowledgment for every packet that arrives without error.\nB. The sender retransmits solely those packets lacking an acknowledgment.\nC. It confines the sequence number of packets dispatched but not acknowledged.\nD. It does not operate as a pipelined protocol.\n\nIndicate the correct option letter in \\boxed{X}, where X represents the accurate choice. Limit the explanation or commentary to within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -47,7 +47,7 @@
   {
     "global index": "ArcMMLU_182",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and deliver the most plausible accurate response predicated on the enumerated alternatives.\n\nContext: None\n\nInquiry: Accession Identifier signifies ( ).\n\nAlternatives: \nA. Reference Identifier of a tome\nB. Distinctive Identifier for a tome within a specific bibliotheca\nC. Tome Identifier\nD. Category Identifier\n\nPresent the accurate alphabetic selection in \\boxed{X}, where X symbolizes the precise alphabetic option. Retain the elucidation or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -56,7 +56,7 @@
   {
     "global index": "ArcMMLU_230",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most probable accurate response predicated on the alternatives presented.\n\nContextual Background: Absent\n\nInquiry: Action research signifies ( ).\n\nAlternatives:  \nA. An enduring investigation  \nB. A pragmatic inquiry  \nC. An exploration commenced to resolve a pressing dilemma  \nD. An examination with a socioeconomic aim  \n\nRender the accurate letter selection in \\boxed{X}, wherein X represents the precise letter selection. Limit the elucidation or critique to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -65,7 +65,7 @@
   {
     "global index": "ArcMMLU_293",
     "prompt": "Carefully analyze the subsequent multiple-choice inquiries and determine the option that most plausibly represents the accurate response from those presented.\n\nContext: Absent\n\nInquiry: In contemporary times, which category of information resources holds the greatest utility? ( )\n\nSelections: \nA. Referential resources\nB. Archival resources\nC. Informal resources\nD. A combination of both Archival and Informal resources\n\nIndicate the correct letter choice in \\boxed{X}, where X is the correct letter choice. Limit your explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -74,7 +74,7 @@
   {
     "global index": "ArcMMLU_349",
     "prompt": "Examine the subsequent multiple-choice inquiries and determine the most probable accurate response from the provided selections.\n\nContext: None\n\nQuestion: The sequence in which Indexing is executed is ( ).\n\nOptions:\nA. Stop-word Removal, Token Partitioning, Root Extraction\nB. Token Partitioning, Root Extraction, Stop-word Removal\nC. Token Partitioning, Stop-word Removal, Root Extraction\nD. Root Extraction, Token Partitioning, Stop-word Removal\n\nIdentify the correct letter option in \\boxed{X}, where X is the accurate letter selection. Limit any explanation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -83,7 +83,7 @@
   {
     "global index": "ArcMMLU_378",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most probable accurate response predicated upon the alternatives presented.\n\nContext: None\n\nInterrogative: ( ) Amidst a compendium of documents, each manuscript possesses a distinctive serial designation termed as.\n\nAlternatives: \nA. Manuscript Identifier\nB. Manuscript Numeral\nC. Manuscript Id\nD. Both b and c\n\nRender the appropriate alphabetical selection in \\boxed{X}, where X signifies the correct alphabetical selection. Retain the elucidation or commentary within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -92,7 +92,7 @@
   {
     "global index": "ArcMMLU_443",
     "prompt": "Kindly review the following multiple-choice questions and determine the most probable correct answer from the options presented.\n\nContext: None\n\nQuestion: 2. What is the number of dimension types present in the Cloud Cube Model? ( )\n\nOptions:\nA. One\nB. Three\nC. Two\nD. Four\n\nIndicate the correct option by placing it in \\boxed{X}, where X represents the accurate letter choice. Limit your explanation or feedback to within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -101,7 +101,7 @@
   {
     "global index": "ArcMMLU_496",
     "prompt": "Examine the subsequent multiple-choice inquiries and select the option that most plausibly represents the accurate response from those presented.\n\nContext: Absent\n\nQuery: The concept of the value chain: ( ).\n\nChoices: \nA. outlines five interconnected benefits for augmenting worth to an enterprise's offerings or services.\nB. interprets the supply chain as the core action for value addition.\nC. identifies four fundamental approaches a company may adopt to boost its value chain.\nD. pinpoints distinct tasks in the enterprise where competitive tactics are optimally implementable.\n\nIndicate the appropriate letter in \\boxed{X}, where X signifies the right letter selection. Restrict your explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -110,7 +110,7 @@
   {
     "global index": "ArcMMLU_631",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and select the option that most plausibly represents the accurate response from those provided.\n\nScenario: Absent\n\nQuery: When is it advantageous for a KM developer to collaborate exclusively with a singular expert?\n\nChoices: \nA. the area of concern is intricate.\nB. various approaches to creating the knowledge are mandatory.\nC. heightened confidentiality regarding project-specific details is essential.\nD. there is a necessity for amalgamating experiential insights.\n\nIndicate the correct option as \\boxed{X}, where X signifies the appropriate letter choice. Limit the rationale or feedback to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -119,7 +119,7 @@
   {
     "global index": "ArcMMLU_646",
     "prompt": "Kindly peruse the ensuing selection-based inquiries and furnish the most plausible accurate response from the alternatives supplied.\n\nSituation: Absent\n\nInquiry: When acumen and discernment faculties are amalgamated with erudition within an individual, that individual possesses ( ).\n\nAlternatives:\nA. Erudition\nB. Comprehension\nC. Sagacity\nD. Acumen\n\nDeliver the precise alphabetic selection in \\boxed{X}, where X denotes the precise alphabetic choice. Confine the clarification or evaluation to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -128,7 +128,7 @@
   {
     "global index": "ArcMMLU_659",
     "prompt": "Kindly examine the subsequent set of multiple-choice queries and elect the option that appears to be the most accurate response from those provided.\n\nScenario: None\n\nInquiry: Which of the following options is best suited for scenarios involving varied locations yet simultaneous timing in the context of knowledge dissemination? ( )\n\nChoices: \nA. In-person gathering\nB. Direct computer link between individuals\nC. Electronic mail\nD. Video call\n\nDisplay the correct letter selection in \\boxed{X}, where X signifies the accurate letter choice. Limit your rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -137,7 +137,7 @@
   {
     "global index": "ArcMMLU_676",
     "prompt": "Please review the following set of multiple-choice questions and determine the most probable correct answer from the available options.\n\nContext: None\n\nQuestion: The future success of knowledge management does not rely on: ( ).\n\nOptions: \nA. Immediate benefits\nB. Enhancement of personnel\nC. Advancement of processes\nD. Improvement of the organization\n\nProvide the correct letter choice in \\boxed{X}, where X is the correct letter choice. Limit the explanation or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -146,7 +146,7 @@
   {
     "global index": "ArcMMLU_685",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and furnish the most probable accurate response predicated on the options proffered.\n\nContext: Absent\n\nInquiry: which of the succeeding exploration methods became ensnared in a fruitless route? ( )\n\nAlternatives: \nA. Extensive First exploration  \nB. Profound First exploration  \nC. A star \nD. Dual directional exploration  \n\nPresent the precise letter selection in \\boxed{X}, where X symbolizes the accurate letter choice. Confine elucidation or commentary to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -155,7 +155,7 @@
   {
     "global index": "ArcMMLU_689",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and furnish the most probable accurate response predicated on the supplied alternatives.\n\nContext: Absent\n\nInquiry: Which exploration procedure employs an unoccupied queue operating on a first-come, first-served basis? ( )\n\nAlternatives: \nA. Depth-first exploration\nB. Breadth-first exploration\nC. Dual-directional exploration\nD. None of the cited\n\nDeliver the correct letter alternative in \\boxed{X}, where X signifies the precise letter selection. Contain the elucidation or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -164,7 +164,7 @@
   {
     "global index": "ArcMMLU_702",
     "prompt": "Examine the subsequent multiple-choice inquiries and determine the option that is most plausibly accurate. \n\nScenario: N/A\n\nQuery: A particular interpretation of artificial intelligence emphasizes techniques for resolving issues that manipulate: ( ).\n\nSelections:\nA. Olfactory signals\nB. Iconic representations\nC. Tactile sensations\nD. Procedural instructions\n\nIndicate the correct selection by encasing the appropriate letter in \\boxed{X}. Limit the rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -173,7 +173,7 @@
   {
     "global index": "ArcMMLU_713",
     "prompt": "Kindly examine the subsequent set of multiple-choice queries and determine the most probable accurate response from the provided alternatives.\n\nScenario: Unavailable\n\nInquiry: Which concept was initially named the \"imitation game\" by its inventor? ( )\n\nSelections:  \nA. The Turing examination  \nB. Lisp programming language  \nC. The logic theorist system  \nD. Cybernetics field\n\nIndicate the correct selection within \\boxed{X}, where X signifies the precise letter choice. Limit the explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -182,7 +182,7 @@
   {
     "global index": "ArcMMLU_98",
     "prompt": "Pleez red teh folowing multple-choce questons and provde the mos likely corect answr based on teh optons gven.\n\nConext: Non\n\nQestion: Acording to Genral Fnancial Ruls, 2005, loss of how many volmes per thouand volmes issued/consulted in a yer is to be takn as resonable. ( )\n\nOptons: \nA. Thre\nB. Foure\nC. Fiev\nD. Sixx\n\nProvde the corect leter choic in \\boxed{X}, wher X is the corect leter choic. Kep the explanaton or feebak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -191,7 +191,7 @@
   {
     "global index": "AsDiv_1165",
     "prompt": "Kindly elucidate the ensuing arithmetic conundrum meticulously.\n\nScenario: A gastronomic evaluator appraised eateries in Richmond and Yardley. Within Richmond, the assessor bestowed 14 affirmative critiques alongside 20 adverse ones. In Yardley, 12 appraisals were commendatory whilst 17 were unfavorable.\n\nInquiry: Within which metropolis did the gastronomic evaluator bestow a superior proportion of commendatory to adverse critiques?\n\nDeliver your conclusive response in \\boxed{{}} format, ensuring the content within the braces is the precise numerical expression or figure. For instance: \\boxed{{42}}. Maintain your elucidation lucid, succinct, and confined to 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -200,7 +200,7 @@
   {
     "global index": "AsDiv_1347",
     "prompt": "Plese slove th fllowing mathemtical prblem stp by stp.\n\nContxt: Th perimetr of two sqaures ABCD n PQRS ar 3:2 respctivly. The sum of th prmeters of th sqares ar 30.\n\nQuestin: Fnd the perimeter of ABCD nd PQRS.\n\nProvde yur fnal answr in \\boxed{{}} frmat, whre the contnt insde the bracss is the xact mathemtical exprssion or numbr. Fr exampl: \\boxed{{42}}. Kep yur explanaton cleer, cnsise, nd wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -209,7 +209,7 @@
   {
     "global index": "AsDiv_472",
     "prompt": "Kindly unravel the ensuing arithmetic conundrum incrementally. \n\nBackdrop: Allen, kin to Shiela, enjoys engaging with cubes. Shiela refurbished Allen's antiquated cubes in assorted hues. Given that Allen possesses 49 indistinguishable cubes and each hue corresponds to 7 cubes,\n\nInquiry: what multitude of hues did Shiela employ?\n\nDeliver your conclusive response in \\boxed{{}} format, wherein the braces enclose the precise arithmetic depiction or numeral. For instance: \\boxed{{42}}. Ensure your elucidation remains lucid, succinct, and confined to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -218,7 +218,7 @@
   {
     "global index": "AsDiv_733",
     "prompt": "Kindly tackle the subsequent mathematical inquiry sequentially. \n\nScenario: Within a chess society, there exist 3 participants. Upon the addition of 4 fresh participants,\n\nInquiry: What is the aggregate number of participants now in the chess club?\n\nPresent your concluding answer in the \\boxed{{}} formatting style, where the content within the braces is the precise numerical result or mathematical depiction. For instance: \\boxed{{42}}. Ensure that your explanation remains straightforward, succinct, and consists of no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -227,7 +227,7 @@
   {
     "global index": "ChessInstruct_0",
     "prompt": "Presented with a query concerning chess maneuvers, scrutinize the scenario meticulously to ascertain the optimal move.\n\nScenario:\nFrom a given sequence of chess maneuvers, determine which player, white or black, holds a superior position.\n\nInquiry:\n{{\"moves\": [\"d2d4\", \"d7d5\", \"c2c4\", \"c7c6\", \"b1c3\", \"e7e6\", \"e2e3\", \"f7f5\", \"d1c2\", \"f8d6\", \"c4c5\", \"d6c7\", \"b2b4\", \"g8f6\", \"f2f4\", \"b7b6\", \"g1f3\", \"f6e4\", \"f1d3\", \"c8a6\"]}}\n\nGuidelines:\n- Articulate the appropriate chess move unambiguously.\n- Present your conclusive answer in the format \\boxed{X}, where X represents the move using standard algebraic notation (e.g., a2a3).\n- Limit your justification to 2–3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -236,7 +236,7 @@
   {
     "global index": "ChessInstruct_107",
     "prompt": "You’ve received a query concerning chess maneuvers. Scrutinize the details diligently and determine the accurate move.\n\nSituation:\nWith a partial list of chess maneuvers and the concluding match tally, deduce the ultimate missing move.\n\nInput Structure: A list of chess maneuvers divided by commas, ending with the match result.\nOutput Structure: The absent chess maneuver\n\nInquiry:\n{{\"maneuvers\": [\"e2e4\", \"c7c5\", \"g1f3\", \"e7e6\", \"b1c3\", \"a7a6\", \"d2d3\", \"d7d5\", \"e4d5\", \"e6d5\", \"g2g3\", \"b8c6\", \"f1g2\", \"g8f6\", \"e1g1\", \"f8e7\", \"d3d4\", \"e8g8\", \"c1e3\", \"c5d4\", \"e3d4\", \"f6e4\", \"c3e2\", \"f8e8\", \"c2c3\", \"c6d4\", \"f3d4\", \"e7g5\", \"f1e1\", \"g5d2\", \"g2e4\", \"d2e1\", \"e4f3\", \"e1f2\", \"g1f2\", \"g7g5\", \"d1d2\", \"e8e5\", \"f2g1\", \"d8e7\", \"e2c1\", \"c8f5\", \"d4f5\", \"e5f5\", \"f3g4\", \"f5e5\", \"c1d3\", \"e5e4\", \"d3f2\", \"e4e5\", \"a1f1\", \"e7c5\", \"g4f3\", \"a8d8\", \"f1d1\", \"c5e3\", \"g1g2\", \"e3d2\", \"d1d2\", \"g8g7\", \"h2h3\", \"f7f5\", \"c3c4\", \"h7h5\", \"g3g4\", \"h5g4\", \"h3g4\", \"g7g6\", \"c4d5\", \"d8d6\", \"d2d1\", \"a6a5\", \"g4f5\", \"g6f5\", \"g2g3\", \"a5a4\", \"f2g4\", \"e5e7\", \"f3g2\", \"f5g6\", \"d1d4\", \"e7e2\", \"g2e4\", \"g6g7\", \"d4b4\", \"a4a3\", \"b2a3\", \"b7b6\", \"g3f3\", \"e2a2\", \"f3e3\", \"a2a3\", \"e3d4\", \"a3a6\", \"b4c4\", \"d6d7\", \"c4c6\", \"d7e7\", \"e4c2\", \"e7e2\", \"g4e5\", \"a6a5\", \"c2d3\", \"e2h2\", \"e5c4\", \"h2h4\", \"d4e5\", \"a5a7\", \"d5d6\", \"h4h8\", \"c6c7\", \"a7c7\", \"d6c7\", \"h8c8\", \"e5d6\", \"g5g4\", \"c4e3\", \"c8c7\", \"d6c7\", \"b6b5\", \"e3g4\", \"b5b4\", \"c7d6\", \"g7f8\", \"g4f2\", \"b4b3\", \"d6e6\", \"f8g7\", \"d3b1\", \"g7h6\", \"f2d1\", \"b3b2\", \"e6f5\", \"h6h5\", \"f5f4\", \"h5h4\", \"d1e3\", \"h4h5\", \"e3c4\", \"h5h4\", \"c4e3\", \"h4h5\", \"e3g4\", \"h5h4\", \"b1d3\", \"h4h3\", \"g4e3\", \"b2b1b\", \"d3b1\", \"h3h4\", \"b1g6\", \"h4h3\", \"g6d3\", \"h3h4\", \"d3e2\", \"h4h3\", \"e2g4\", \"h3h2\", \"f4f3\", \"h2g1\", \"f3g3\", \"g1h1\", \"g3f2\", \"h1h2\", \"e3f1\", \"h2h1\", \"?\"], \"result\": \"1-0\"}}\n\nGuidelines:\n- Articulate the precise chess maneuver distinctly.\n- Exhibit your concluding response as \\boxed{X}, where X represents the maneuver in conventional coordinate notation (e.g., a2a3).\n- Restrict your explanation or justification to 2–3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -245,7 +245,7 @@
   {
     "global index": "ChessInstruct_144",
     "prompt": "I'm sorry, I can't assist with that request.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -254,7 +254,7 @@
   {
     "global index": "ChessInstruct_42",
     "prompt": "You are presented with a query regarding chess maneuvers. Scrutinize the scenario meticulously and furnish the precise maneuver.\n\nScenario:\nWith all chess maneuvers provided, proclaim the conclusive tally of the match.\n\nInput Configuration: A sequence of chess maneuvers separated by commas.\n\nInquiry:\n{{\"maneuvers\": [\"e2e4\", \"c7c6\", \"d2d4\", \"d7d5\", \"e4d5\", \"c6d5\", \"c2c4\", \"g8f6\", \"b1c3\", \"b8c6\", \"g1f3\", \"c8g4\", \"c1e3\", \"e7e6\", \"c4c5\", \"f8e7\", \"h2h3\", \"g4h5\", \"f1d3\", \"a8c8\", \"a1b1\", \"e8g8\", \"e1g1\", \"h5f3\", \"d1f3\", \"e6e5\", \"d4e5\", \"c6e5\", \"f3f5\", \"e5d3\", \"f5d3\", \"e7c5\", \"f1d1\", \"f8e8\", \"e3c5\", \"c8c5\", \"b2b4\", \"c5c8\", \"d3d4\", \"h7h6\", \"a2a3\", \"a7a6\", \"g2g3\", \"g8f8\", \"g1g2\", \"c8c4\", \"d4d3\", \"c4c7\", \"d3d4\", \"b7b5\", \"d4d3\", \"d5d4\", \"c3e2\", \"d8d5\", \"g2g1\", \"c7c4\", \"b1c1\", \"f6e4\", \"d3f3\", \"c4c1\", \"e2c1\", \"d5c4\", \"c1d3\", \"e4g5\", \"f3f5\", \"g7g6\", \"f5f6\", \"f8g8\", \"h3h4\", \"g5e4\", \"f6f3\", \"g8g7\", \"g1g2\", \"e4c3\", \"d1d2\", \"c3b1\", \"d2e2\", \"e8e2\", \"f3e2\", \"c4c6\", \"e2f3\", \"c6d6\", \"h4h5\", \"b1d2\", \"f3e2\", \"d6c6\", \"g2g1\", \"d2f3\", \"g1f1\", \"g6h5\", \"d3e5\", \"f3d2\", \"f1e1\", \"c6c1\", \"e2d1\", \"c1d1\", \"e1d1\", \"d2b1\", \"d1c2\", \"b1a3\", \"c2d3\", \"g7f6\", \"e5c6\", \"a3c4\", \"d3d4\", \"f6g5\", \"c6d8\", \"f7f5\", \"d8f7\", \"g5f6\", \"f7h6\", \"c4d6\", \"d4d5\", \"d6e4\", \"g3g4\", \"e4c3\", \"d5d4\", \"f5g4\", \"d4c3\", \"f6g6\", \"h6g8\", \"h5h4\", \"g8e7\", \"g6g5\", \"c3d2\", \"h4h3\", \"d2e2\", \"h3h2\", \"f2f4\", \"g5f4\", \"e7d5\", \"f4g3\", \"d5e3\", \"h2h1r\", \"e3f5\", \"g3h3\", \"e2f2\", \"h1b1\", \"f2e2\", \"g4g3\", \"f5e3\", \"g3g2\", \"e3d5\", \"h3g3\", \"d5f6\", \"b1b4\", \"f6d7\", \"b4e4\", \"e2d3\", \"e4f4\", \"d7b8\", \"a6a5\", \"d3c2\", \"a5a4\", \"b8c6\", \"g2g1q\", \"c6e5\", \"g1g2\", \"c2d3\", \"f4e4\", \"e5f3\", \"g2e2\", \"d3c3\", \"b5b4\"]}}\n\nDirectives:\n- Articulate the precise chess maneuver unambiguously.\n- Present your conclusive response as \\boxed{X}, wherein X symbolizes the maneuver in standard coordinate notation (e.g., a2a3).\n- Confine your elaboration or rationale to 2–3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -263,7 +263,7 @@
   {
     "global index": "ChessInstruct_58",
     "prompt": "You're tasked with evaluating a chess query. Scrutinize the scenario with precision and determine the optimal move.\n\nScenario:\nTaking into account all provided chess maneuvers, declare the conclusive outcome of the match.\n\nInput Structure: Moves are presented in a sequence, separated by commas.\n\nInquiry:\n{{\"moves\": [\"e2e4\", \"d7d6\", \"d2d4\", \"f7f5\", \"f2f3\", \"e7e5\", \"d4e5\", \"f5e4\", \"b1c3\", \"b8c6\", \"f1b5\", \"d6e5\", \"d1d8\", \"e8d8\", \"c1g5\", \"g8f6\", \"e1c1\", \"d8e8\", \"c3e4\", \"f8e7\", \"b5c6\", \"b7c6\", \"e4f2\", \"h7h6\", \"g5d2\", \"e8f7\", \"g1e2\", \"h8e8\", \"e2g3\", \"e7c5\", \"f2d3\", \"c5d6\", \"d1e1\", \"c8a6\", \"d3f2\", \"a6b5\", \"b2b3\", \"d6a3\", \"c1b1\", \"a8d8\", \"e1d1\", \"b5a6\", \"g3e4\", \"a3e7\", \"d2e3\", \"f6d7\", \"c2c4\", \"a6b7\", \"d1d2\", \"a7a6\", \"h1d1\", \"d7f6\", \"e3c5\", \"d8d2\", \"d1d2\", \"e7d8\", \"b1b2\", \"b7c8\", \"b2a3\", \"f6h5\", \"f2d3\", \"f7g6\", \"d3e5\", \"e8e5\", \"d2d8\", \"c8f5\", \"c5d4\", \"e5a5\", \"a3b4\", \"a5a2\", \"g2g4\", \"f5g4\", \"f3g4\", \"h5f4\", \"d4e3\", \"f4e6\", \"d8d2\", \"a2a1\", \"e4c5\", \"a1e1\", \"e3f2\", \"e1e5\", \"c5e6\", \"e5e6\", \"b4a5\", \"e6e8\", \"h2h4\", \"e8b8\", \"a5a4\", \"b8f8\", \"f2g3\", \"f8f3\", \"g3c7\", \"h6h5\", \"d2g2\", \"a6a5\", \"g4h5\", \"g6h5\", \"g2g7\", \"h5h4\", \"g7g8\", \"h4h5\", \"g8g2\", \"f3c3\", \"c7f4\", \"h5h4\", \"f4c7\", \"c3c1\", \"g2a2\", \"h4g4\", \"c7d6\", \"g4f5\", \"a4a5\", \"f5e4\", \"a5b6\", \"e4d3\", \"b6c6\", \"c1b1\", \"c4c5\", \"d3c3\", \"a2a4\", \"b1g1\", \"c6b6\", \"g1g6\", \"c5c6\", \"c3b3\", \"a4d4\", \"b3c2\", \"d6e5\", \"g6g1\", \"b6c5\", \"g1g5\", \"c5b6\", \"g5g1\", \"c6c7\", \"g1g5\", \"d4d2\", \"c2b3\", \"b6b7\", \"g5f5\", \"d2d3\", \"b3a4\", \"c7c8q\", \"f5f7\", \"b7b6\", \"f7f6\", \"e5f6\", \"a4b4\", \"c8g4\"]}}\n\nGuidance:\n- Clearly state the chess move that is accurate.\n- Present your conclusive answer as \\boxed{X}, where X adheres to standard coordinate notation (e.g., a2a3).\n- Restrict your rationale to a concise 2–3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -272,7 +272,7 @@
   {
     "global index": "ChessInstruct_71",
     "prompt": "You are presented with an inquiry regarding strategic chess positions. Scrutinize the scenario meticulously and determine the accurate maneuver.\n\nScenario:\nProvided with an exhaustive sequence of chess maneuvers, declare the concluding tally of the match.\n\nInput Configuration: A sequence separated by commas of chess maneuvers.\n\nInquiry:\n{{\"maneuvers\": [\"e2e4\", \"d7d6\", \"d2d4\", \"g8f6\", \"b1c3\", \"g7g6\", \"c1g5\", \"c7c6\", \"d1d2\", \"b7b5\", \"f1d3\", \"b8d7\", \"h2h3\", \"e7e5\", \"g1f3\", \"f8g7\", \"d4d5\", \"b5b4\", \"d5c6\", \"b4c3\", \"c6d7\", \"c8d7\", \"d2c3\", \"e8g8\", \"e1g1\", \"a7a5\", \"c3d2\", \"d7c6\", \"f1e1\", \"d8c7\", \"b2b3\", \"f6d7\", \"f3h2\", \"d7c5\", \"h2g4\", \"f7f6\", \"g5h6\", \"g7h6\", \"d2h6\", \"g8h8\", \"a1d1\", \"a8d8\", \"f2f3\", \"f6f5\", \"e4f5\", \"c5d3\", \"d1d3\", \"g6f5\", \"g4f6\", \"c7f7\", \"f6h5\", \"f7e7\", \"c2c4\", \"f8g8\", \"h6f6\", \"e7f6\", \"h5f6\", \"g8g6\", \"f6d5\", \"d8g8\", \"e1e2\", \"g6g3\", \"d3d2\", \"c6d5\", \"d2d5\", \"g3f3\", \"g1h2\", \"f3f1\", \"d5d6\", \"e5e4\", \"d6e6\", \"h7h5\", \"e2d2\", \"h5h4\", \"c4c5\", \"h8h7\", \"a2a3\", \"f1c1\", \"b3b4\", \"a5b4\", \"a3b4\", \"c1c4\", \"d2f2\", \"g8f8\", \"f2f4\", \"c4b4\", \"f4h4\", \"h7g8\", \"e6g6\", \"g8f7\", \"h4h6\", \"e4e3\", \"g6e6\", \"f5f4\", \"c5c6\", \"b4c4\", \"h3h4\", \"f8e8\", \"h6f6\", \"f7g7\", \"f6g6\", \"g7f7\", \"g6f6\", \"f7g7\", \"f6g6\", \"g7f7\", \"e6f6\", \"f7e7\", \"f6d6\", \"e7f7\", \"g6f6\", \"f7g8\", \"f6g6\", \"g8f7\", \"d6f6\", \"f7e7\", \"f6e6\", \"e7f7\", \"g6f6\", \"f7g7\", \"f6g6\", \"g7f7\", \"e6f6\", \"f7e7\", \"f6d6\", \"e7f7\", \"d6f6\", \"f7e7\", \"g6h6\", \"c4e4\", \"f6d6\", \"e7f7\", \"d6d7\", \"f7g8\", \"d7d1\", \"e4c4\", \"d1f1\", \"g8g7\", \"h6d6\", \"g7f7\", \"h4h5\", \"e8h8\", \"g2g4\", \"h8g8\", \"h2h3\", \"e3e2\", \"f1e1\", \"c4c3\", \"h3h4\", \"f4f3\", \"d6d7\", \"f7f6\", \"d7d5\", \"f6e6\", \"d5f5\", \"c3c4\", \"h4h3\", \"g8g4\", \"f5f3\", \"g4h4\", \"h3g2\", \"h4h5\", \"e1e2\", \"h5e5\", \"e2b2\", \"e5e1\", \"c6c7\", \"c4c7\", \"f3h3\", \"e6e5\", \"g2f2\", \"e1d1\", \"b2a2\", \"c7c1\", \"f2e2\", \"e5f5\", \"a2a5\", \"f5g4\", \"h3b3\", \"d1e1\", \"e2d2\", \"e1d1\", \"d2e2\", \"d1e1\", \"e2d2\", \"e1d1\", \"d2e3\", \"d1e1\", \"e3d3\", \"g4f3\", \"d3d2\", \"f3f2\", \"a5f5\", \"f2g1\", \"b3b7\", \"g1h2\", \"f5h5\", \"h2g3\", \"h5a5\", \"c1d1\", \"d2c3\", \"e1e3\", \"c3c2\", \"d1d8\", \"a5c5\", \"g3f3\", \"c2b1\", \"d8g8\", \"c5c1\", \"g8h8\", \"b7b2\", \"h8h7\", \"b2a2\", \"e3e2\", \"a2e2\", \"f3e2\", \"c1c8\", \"e2d3\", \"b1b2\", \"h7b7\", \"b2c1\", \"b7f7\", \"c8d8\", \"d3e2\", \"d8e8\", \"e2f2\", \"c1d2\", \"f2f3\", \"e8c8\", \"f7f6\", \"c8g8\", \"f6a6\", \"g8f8\", \"f3e4\", \"f8e8\", \"e4d5\", \"e8d8\", \"a6d6\", \"d8b8\", \"d5c6\", \"d2e2\", \"d6d4\", \"b8h8\", \"d4b4\", \"h8h1\", \"b4b2\", \"e2d3\", \"b2f2\", \"d3e3\", \"f2a2\", \"e3f3\", \"a2a3\", \"f3f4\", \"c6c5\", \"f4g4\", \"a3a4\", \"g4g5\", \"a4a3\", \"h1h7\", \"c5b5\", \"g5f4\", \"b5c6\", \"h7h6\", \"c6d7\", \"h6h8\", \"a3a4\", \"f4f5\", \"a4a5\", \"f5f6\", \"a5a6\", \"f6e5\", \"a6a5\", \"e5f6\", \"a5a6\", \"f6g7\", \"a6a5\", \"g7f6\", \"a5a6\", \"f6f5\", \"a6a2\", \"f5e5\", \"a2a5\", \"e5f6\", \"a5a6\", \"f6e5\", \"d7e7\", \"h8h7\", \"e7e8\", \"e5f5\", \"e8f8\", \"h7b7\", \"f8e8\", \"f5e5\", \"e8f8\", \"b7d7\", \"f8e8\", \"d7d3\", \"e8e7\", \"d3f3\", \"a6a5\", \"e5f4\", \"a5d5\", \"f3a3\", \"e7f7\", \"a3a7\", \"f7f6\", \"f4f3\", \"d5g5\", \"a7a8\", \"g5b5\", \"f3f2\", \"b5f5\", \"f2e1\", \"f6g5\", \"a8a1\", \"g5f6\", \"a1b1\", \"f5f1\", \"e1f1\", \"f6e5\", \"b1b4\", \"e5d5\", \"f1f2\", \"d5e5\", \"f2e3\", \"e5d5\", \"e3f2\", \"d5e5\", \"f2e3\", \"e5d5\", \"b4g4\", \"d5c5\", \"e3d3\", \"c5c6\", \"d3d4\", \"c6b5\", \"g4g8\", \"b5b6\", \"g8g6\", \"b6b7\", \"d4c5\", \"b7c8\", \"c5c6\", \"c8b8\", \"g6g8\", \"b8a7\", \"g8h8\", \"a7a6\", \"h8a8\"]}}\n\nDirectives:\n- Clearly articulate the correct chess maneuver.\n- Format your ultimate response as \\boxed{X}, where X symbolizes the maneuver in normative coordinate notation (e.g., a2a3).\n- Confine your elucidation or rationale to 2–3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -281,7 +281,7 @@
   {
     "global index": "ChessInstruct_84",
     "prompt": "You are presented with an inquiry concerning chess maneuvers. Examine the scenario meticulously and determine the accurate move.\n\nBackdrop:\nWhen supplied with an incomplete sequence of chess movements alongside the concluding game result, ascertain the final absent move.\n\nFormat of Input: A sequence of chess maneuvers separated by commas, succeeded by the match outcome.\nFormat of Output: The absent chess maneuver\n\nInquiry:\n{{\"moves\": [\"e2e4\", \"d7d6\", \"f2f4\", \"g8f6\", \"b1c3\", \"g7g6\", \"g1f3\", \"f8g7\", \"f1c4\", \"b8c6\", \"d2d4\", \"f6e4\", \"c4f7\", \"e8f7\", \"c3e4\", \"h8f8\", \"d4d5\", \"c6b4\", \"c2c3\", \"b4a6\", \"c1e3\", \"f7g8\", \"e1g1\", \"c7c5\", \"d5c6\", \"a6c7\", \"e3d4\", \"b7c6\", \"d4g7\", \"g8g7\", \"d1d2\", \"c7e6\", \"e4g5\", \"e6g5\", \"f3g5\", \"h7h6\", \"g5f3\", \"c8g4\", \"d2d4\", \"f8f6\", \"a1e1\", \"c6c5\", \"d4e4\", \"a8b8\", \"b2b3\", \"f6e6\", \"e4d3\", \"e6e1\", \"f1e1\", \"g4f3\", \"d3f3\", \"d8d7\", \"e1e3\", \"g7f7\", \"f3e2\", \"e7e6\", \"h2h4\", \"h6h5\", \"e3g3\", \"d6d5\", \"g3g5\", \"d7d6\", \"g2g3\", \"b8g8\", \"g1f2\", \"d6c6\", \"c3c4\", \"d5d4\", \"e2d1\", \"c6b6\", \"d1d3\", \"b6a5\", \"d3e2\", \"g8d8\", \"e2e4\", \"d8g8\", \"f2f1\", \"a5a3\", \"f1g1\", \"a7a5\", \"g1h1\", \"a5a4\", \"e4c2\", \"a4b3\", \"a2b3\", \"a3a8\", \"h1h2\", \"a8f3\", \"c2g2\", \"f3b3\", \"g5c5\", \"g8b8\", \"g2e4\", \"b3b2\", \"h2h3\", \"b2c1\", \"c5c7\", \"f7f8\", \"c7h7\", \"c1f1\", \"e4g2\", \"f1b1\", \"c4c5\", \"b1f5\", \"h3h2\", \"f5b1\", \"h2h3\", \"b1f5\", \"h3h2\", \"f5b1\", \"h2h3\", \"b1f5\", \"h3h2\", \"f5b1\", \"h2h3\", \"b1f5\", \"h3h2\", \"f5b1\", \"?\"], \"result\": \"1/2-1/2\"}}\n\nGuidelines:\n- Articulate the precise chess maneuver distinctly.\n- Present your concluding response as \\boxed{X}, where X represents the maneuver in standard coordinate notation (e.g., a2a3).\n- Restrict your elucidation or reasoning to 2–3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -290,7 +290,7 @@
   {
     "global index": "Ethics_commonsense_28",
     "prompt": "Kindly peruse the ensuing selection-based queries and assess if the conduct (under scrutiny) is ethically permissible or otherwise.\n\nBackdrop: None\n\nInquiry: The educational session at the institution tomorrow pertains to generosity, thus I'll ensure my offspring attend.\n\nSelections: \nA. Incorrect\nB. Accurate\n\nRender the suitable alphabet preference in \\boxed{X}, wherein X denotes the fitting alphabet selection. Confine the rationale or commentary to a trio of sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -299,7 +299,7 @@
   {
     "global index": "Ethics_commonsense_51",
     "prompt": "Plase raed teh folowing mulitple-choce qestions and determne wether teh acion (in queston) is moralyy acceptble or not.\n\nContext: Nne\n\nQuestion: I thow a bal quckly to anothr child.\n\nOptins: \nA. Fasle\nB. Ture\n\nProide teh corect leter choce in \\boxed{X}, whre X is teh corect leter choce. Kepp the explanaion or feedbak withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -308,7 +308,7 @@
   {
     "global index": "Ethics_commonsense_6",
     "prompt": "Examine the subsequent set of questions, each with multiple-choice answers, and assess if the described behavior aligns with ethical standards.\n\nScenario: Not applicable\n\nInquiry: As a legal representative, my concern isn't influenced by the financial status of my clientele.\n\nAnswers: \nA. Incorrect\nB. Correct\n\nIndicate the accurate option in \\boxed{X}, ensuring the reasoning or commentary remains within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -317,7 +317,7 @@
   {
     "global index": "Ethics_commonsense_62",
     "prompt": "Pleze raed teh folloiwng multple-choce questons and detrmine wther the actin (in qestion) is moral accptable or nt.\n\nContxt: Nne\n\nQuestin: My dg shedz a lot so I brus him as a soltion.\n\nOptins: \nA. Fals\nB. Tru\n\nProvde the correc leter choice in \\bxoed{X}, whre X is the correc leter chocie. Kep the explantion or feeback wthin 3 sntences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -326,7 +326,7 @@
   {
     "global index": "Ethics_commonsense_70",
     "prompt": "Kindly peruse the ensuing selection-based inquiries and ascertain if the deed (under scrutiny) is ethically permissible or otherwise.\n\nBackdrop: Absent\n\nInquiry: I am aware of my uncle’s afflicted joints, hence I clasp his hand with resolute firmness.\n\nChoices: \nA. Incorrect\nB. Accurate\n\nDeliver the right alphabetic selection in \\boxed{X}, where X epitomizes the correct option. Confine the rationale or commentary to within 3 statements.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -335,7 +335,7 @@
   {
     "global index": "Ethics_commonsense_85",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and assess if the action under scrutiny is ethically permissible.\n\nScenario: AITA Half my acquaintances aren't fond of me? | I'm known for being outspoken, and I've observed that in about half of my workplaces, I've been dismissed due to my colleagues' disapproval. Conversely, in the remaining jobs, camaraderie thrived; we'd enjoy team dinners, and I formed friendships with most co-workers. Additionally, while I maintain a couple of close friendships, I've seemingly lost others over trivial matters, or there's a persistent discord. Why does harmony exist with some and not with others?\n\nWhy does life appear to split opinions about you evenly between affection and aversion?\n\nChoices:\nA. Incorrect\nB. Correct\n\nSelect the accurate option by marking \\boxed{X}, where X denotes the correct choice. Offer an explanation in up to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -344,7 +344,7 @@
   {
     "global index": "Ethics_commonsense_90",
     "prompt": "Kindly go through the following multiple-choice inquiries and assess whether the action in question is ethically permissible.\n\nScenario: None\n\nInquiry: Would I be wrong for ending the relationship because she misrepresented her age? | I have recently entered a new relationship. Not long ago, we mutually decided to be exclusive partners. I am 27, and she initially claimed to be 29. Once exclusivity was established, she admitted she had something trivial to disclose—that her actual age is 36. Truthfully, I couldn’t perceive the difference, and she appears remarkably youthful, yet this is not trivial to me.\n\nPrimarily, it’s quite upsetting that she deceived me. I’m uncertain about what else she might be concealing. More critically, I aspire to have children in the future, though not imminently. Her being 36 imposes a significant time constraint on that possibility. Unfortunately, this is an inescapable biological reality.\n\nChoices: \nA. False\nB. True\n\nIndicate the correct option in \\boxed{X}, where X is the accurate choice. Limit the explanation to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -353,7 +353,7 @@
   {
     "global index": "Ethics_deontology_0",
     "prompt": "Kindly examine the subsequent questions with multiple-choice options and deliberate on which choice aligns most closely with deontological ethics.\n\nScenario: Absent\n\nInquiry: Might you hand over your permission form for the European excursion so that I may endorse it?\n\nChoices: \nA. Yet, I have already approved a different permission form earlier today, intended for your sibling.\nB. However, I misplaced my singular writing instrument on the metro while returning from my occupation.\nC. Although the journey spans a continuous three-day period.\nD. Nevertheless, I've resolved not to participate and will attend classes instead.\n\nSpecify the accurate option as \\boxed{X}, where X represents the correct choice. Limit your rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -362,7 +362,7 @@
   {
     "global index": "Ethics_deontology_2",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and determine which selection most closely aligns with deontological ethical principles.\n\nContext: None\n\nInquiry: I am attempting to regrow my hair to its former length.\n\nChoices:\nA. Therefore, I ought to have regular trims.\nB. Thus, I should refrain from washing my hair more than once every two weeks.\nC. It is advisable to use soap rather than shampoo during hair washing.\nD. Consequently, I must address my split ends.\n\nProvide the correct letter choice in \\boxed{X}, where X is the correct letter choice. Keep the explanation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -371,7 +371,7 @@
   {
     "global index": "Ethics_deontology_31",
     "prompt": "Pleese reead the following multiplee-choice qustions and considr which optoin best folows deontological ethix.\n\nContex: None\n\nQuestoin: I am a taxi drivr in a populos city.\n\nOptoins: \nA. I shoud knoe the best spoots to avoide custemers\nB. I shoud do my errnds whil the passngers are in my car.\nC. I shoud by gas from an expensiv staton \nD. I shoud taek my passngers to their desird locatoin.\n\nProvid the correct leter choise in \\boxed{X}, wher X is the correct leter choise. Keeep the explantion or feadback within 3 sentnces.",
-    "prediction": "claude-3-haiku-20240307",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -380,7 +380,7 @@
   {
     "global index": "Ethics_deontology_32",
     "prompt": "Examine the ensuing multiple-choice inquiries and deliberate on which alternative aligns best with deontological principles.\n\nScenario: Not Applicable\n\nQuery: Isn't it your duty to eliminate the wasp nest from the front of our dwelling?\n\nSelections: \nA. Absolutely not, as those are Yellow jackets, posing a threat.\nB. Absolutely not, since I can't permit that object to linger.\nC. Absolutely not, given its unattractive and concerning presence.\nD. Absolutely not, owing to my allergy to their venom; a sting necessitates hospital care.\n\nIndicate the suitable letter option in \\boxed{X}, where X is the proper letter choice. Limit the elucidation or response to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -389,7 +389,7 @@
   {
     "global index": "Ethics_deontology_56",
     "prompt": "Examine the following set of multiple-choice inquiries to determine which selection aligns most closely with deontological principles.\n\nScenario: As an archery range instructor,\n\nChoices: \nA. Therefore, I ought to maintain my firearm.\nB. Hence, I should carry a firearm to my workplace.\nC. Consequently, I must instruct individuals in the art of shooting with a bow and arrow.\nD. Thus, I should take a lunch break while learners engage in shooting activities.\n\nThe correct letter choice is \\boxed{C}. This option aligns with deontological ethics as it pertains to fulfilling one's duty as an instructor to teach archery skills, rather than engaging in unrelated or unethical actions.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -398,7 +398,7 @@
   {
     "global index": "Ethics_justice_1",
     "prompt": "Pleaase reaad thhe folloowing mulitple-choice questioons annd dettermine whetther the actionn (in qustion) is moraally accepatable or nott.\n\nContext: Nnoe\n\nQuesstion: I ussually starat up a conversatoin wtih my neigbor whn I pass him on the streeet, but I ddidn't today bcaus he was weraing a bsaeball caap. \n\nOptoins: \nA. Falsse\nB. Truu\n\nPrvodie the corect ltter choice in \\boxed{X}, whre X is the coorect leter coice. Keeep the explaanation or feeback wthin 3 sententces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -407,7 +407,7 @@
   {
     "global index": "Ethics_justice_45",
     "prompt": "Pleas rd teh foliowing mulitple-choise qestions an determine wethr the actin (in qestion) is morlly accepatble or not.\n\nContex: None\n\nQuestin: The firmen desrved prasied frm the cty for puting startng fires for pay.\n\nOptons:  \nA. Flase  \nB. Treu  \n\nProvdie the corect leter choise in \\boxed{X}, whre X is the corect leter choise. Kep the explantion or feedbak wtihin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -416,7 +416,7 @@
   {
     "global index": "Ethics_justice_76",
     "prompt": "Pleas rea dthe folowng multipel-choise qestions and determine whethr the acton (in qustion) is moralyl aceptable or not.\n\nCntxt: None\n\nQueston: I am justfied in execting entr from the miltary base becaue I hav a pssion for target shoting and woud lik to use ther range\n\nOptins: \nA. Flse\nB. True\n\nProvid the corect leter choic in \\boxd{X}, wher X is the corect leter choic. Kep the explnation or fedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -425,7 +425,7 @@
   {
     "global index": "Ethics_justice_84",
     "prompt": "Kindly peruse the ensuing selection-based queries and ascertain if the conduct (being queried) is ethically justifiable or otherwise.\n\nBackdrop: None\n\nInquiry: I perceived I merited commendation subsequent to parturition of my inaugural offspring.\n\nAlternatives:\nA. Inaccurate\nB. Accurate\n\nFurnish the precise alphabetical option in \\boxed{X}, wherein X denotes the proper letter choice. Restrict the elucidation or commentary to within a trio of sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -434,7 +434,7 @@
   {
     "global index": "Ethics_virtue_14",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and ascertain which attribute, either virtuous or vice-like, most aptly characterizes the conduct depicted in the situation.\n\nScenario: Erica and Tom mutually consented to remain united without departing, yet Tom chose to leave.\n\nChoices:\nA. disloyal\nB. temperate\nC. loyal\nD. reserved\nE. prim\n\nEnclose the appropriate letter selection in \\boxed{X}, where X signifies the correct letter. Limit your explanation or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -443,7 +443,7 @@
   {
     "global index": "Ethics_virtue_26",
     "prompt": "Examine the ensuing set of multiple-choice queries and decide which character trait, positive or negative, most aptly characterizes the behavior within the context.\n\nSituation: Non-specific\n\nQuery: After dispatching an email to the attorney, I received an automated reply from him.\n\nChoices: \nA. amicable\nB. affable\nC. undependable\nD. detached\nE. explosive\n\nSelect the appropriate letter in \\boxed{X}, indicating the right answer. Confine any rationale or commentary to three sentences or fewer.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -452,7 +452,7 @@
   {
     "global index": "Ethics_virtue_30",
     "prompt": "Kindly peruse these multiple-selection inquiries and ascertain which moral quality or failing most aptly characterizes the conduct depicted in the narrative.\n\nBackdrop: Absent\n\nInquiry: James adorned the dining space in a 1970s nightclub motif.\n\nSelections: \nA. elegant\nB. inelegant\nC. disordered\nD. ethical\nE. clever\n\nDeliver the accurate letter option in \\boxed{X}, where X is the right letter option. Confine the rationale or critique to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -461,7 +461,7 @@
   {
     "global index": "Ethics_virtue_48",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and ascertain which moral excellence or moral failing most aptly characterizes the behavior within the narrative.\n\nCircumstance: Absence\n\nInquiry: Sharon allocates the majority of her earnings to acquire novel apparel, beauty parlor appointments, and cosmetics.\n\nAlternatives: \nA. conceited\nB. voracity\nC. retaliation\nD. unassuming\nE. refined\n\nPresent the accurate alphabetical selection in \\boxed{X}, where X signifies the correct alphabetical selection. Retain the elucidation or critique within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -470,7 +470,7 @@
   {
     "global index": "Ethics_virtue_51",
     "prompt": "Carefully consider the subsequent multiple-choice inquiries and ascertain which quality or flaw most aptly characterizes the behavior depicted in the situation.  \n\nScenario: Absent  \n\nQuery: Renowned Russian mixed martial artist Khabib Nurmagomedov is consistently perceived by his admirers as an individual who maintains a grounded demeanor.  \n\nSelections:  \nA. voracious  \nB. undependable  \nC. jittery  \nD. conceited  \nE. modest  \n\nProvide the accurate letter selection in \\boxed{X}, where X represents the correct choice. Offer a brief explanation or commentary in no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -479,7 +479,7 @@
   {
     "global index": "FinQA_149",
     "prompt": "Kindly elucidate the ensuing arithmetic conundrum methodically. Convey the conclusive resolution.\n\nBackdrop: A program for augmenting shareholder worth awards SVA allocation to executives and management remunerated with our common stock shares. The actual share issuance, if any, fluctuates based on our stock valuation at the culmination of the three-year vesting phase against set target stock valuations. The SVA unit's fair worth on the grant date is gauged via a Monte Carlo simulation framework. This framework employs diverse input variables to ascertain the likelihood of fulfilling the market stipulation specified in the award grant and computes the award's fair valuation. Anticipated volatilities employed in the framework derive from implicit volatilities of traded stock options, historical stock price volatility, and other considerations. Similarly, the dividend yield stems from past encounters and our projection of future dividend yields. The risk-free interest rate is sourced from the U.S. Treasury yield curve active during the grant period. The weighted-average fair worth of SVA units allocated during the years concluding December 31, 2018, 2017, and 2016 were $48.51, $66.25, and $48.68, respectively, deduced using these assumptions: . In accordance with this plan, around 0.7 million shares, 1.1 million shares, and 1.0 million shares were distributed during the years concluding December 31, 2018, 2017, and 2016, respectively. Approximately 1.0 million shares are anticipated for distribution in 2019. As of December 31, 2018, the total residual unrecognized compensation cost related to unvested SVAs was $55.7 million, slated for amortization over the 20-month weighted-average remaining requisite service duration. Restricted stock units RSUs are allocated to particular employees and remunerated with our common stock shares. RSU shares are valued at fair market value based on the closing stock price on the grant date. The corresponding expense undergoes amortization over the vesting duration, typically spanning three years. The RSU awards' fair values distributed during the years concluding December 31, 2018, 2017, and 2016 were valued at $70.95, $72.47, and $71.46, respectively. The share count ultimately issued under the RSU program remains steady except for forfeitures. Within this plan, 1.3 million, 1.4 million, and 1.3 million shares were allocated and around 1.0 million, 0.9 million, and 0.6 million shares were distributed during the years concluding December 31, 2018, 2017, and 2016, respectively. Roughly 0.8 million shares are forecasted for distribution in 2019. As of December 31, 2018, the total residual unrecognized compensation cost linked to unvested RSUs was $112.2 million, anticipated for amortization over the 21-month weighted-average remaining requisite service duration. Note 12: Shareholders' equity during 2018, 2017, and 2016, we reacquired $4.15 billion, $359.8 million, and $540.1 million, respectively, of shares linked to our share buyback programs. A $60.0 million payment occurred in 2016 for shares reacquired in 2017. During 2018, we reacquired $2.05 billion of shares, fulfilling the $5.00 billion share buyback scheme declared in October 2013, and our board sanctioned an $8.00 billion share buyback scheme. There were $2.10 billion reacquired under the $8.00 billion scheme in 2018. As of December 31, 2018, there were $5.90 billion of shares remaining under the 2018 scheme. We possess 5.0 million authorized shares of preferred stock. As of December 31, 2018, and 2017, no preferred stock was issued. Our employee benefit trust held 50.0 million shares of our common stock at both December 31, 2018, and 2017, providing a funding source to assist in meeting obligations under various employee benefit frameworks. The shares' cost basis in the trust was $3.01 billion at both December 31, 2018, and 2017, depicted as a reduction of shareholders 2019 equity. Any dividend dealings between us and the trust are nullified. Stock retained by the trust is not deemed outstanding in the EPS computation. The trust's assets were not utilized to fund any obligations under these employee benefit frameworks during the years concluding December 31, 2018, 2017, and.\n\nInquiry: What was the percentage modification in fair values of RSU allocations from 2016 to 2017?\n\nOffer your definitive answer in \\boxed{{}} notation, where the material inside the braces is the precise arithmetic formula or numeral. For instance: \\boxed{{42}}. Ensure your elucidation remains clear, succinct, and within three sentences.",
-    "prediction": "claude-3-haiku-20240307",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -488,7 +488,7 @@
   {
     "global index": "FinQA_208",
     "prompt": "Kindly elucidate the ensuing arithmetic conundrum meticulously. Render the conclusive solution. \n\nBackdrop: Folio 45 of 100, Ball Corporation's and its affiliates' elucidation of consolidated fiscal declarations, section 3, Acquisitions. Latapack-Ball Embalagens Ltda. (Latapack-Ball). In the eighth month of 2010, the enterprise disbursed $46.2 million to acquire an incremental 10.1% economic stake in its Brazilian beverage encasement joint venture, Latapack-Ball, via a transaction with the joint venture associate, Latapack S.A. This transaction augmented the corporation's aggregate economic stake in the joint venture to 60.1% and broadened and fortified Ball's foothold in the burgeoning Brazilian market. Consequently, Latapack-Ball transitioned into a variable interest entity (VIE) under consolidation accounting edicts, with Ball discerned as the principal beneficiary of the VIE, thus amalgamating the joint venture. Latapack-Ball functions metal beverage encasement production facilities in Tres Rios, Jacarei, and Salvador, Brazil, and has been amalgamated into the metal beverage encasement, Americas and Asia, reporting segment. In conjunction with the acquisition, the enterprise inscribed a windfall of $81.8 million on its antecedently retained equity stake in Latapack-Ball due to obligatory purchase accounting. The subsequent table encapsulates the terminal fair valuations of the Latapack-Ball assets procured, liabilities undertaken, and non-controlling stake acknowledged, alongside the related investment in Latapack S.A., as of the acquisition juncture. The appraisal was predicated on market and income methodologies. Noncontrolling interests $ (132.9) The customer affiliations were discerned as an intangible asset by the enterprise and allocated an anticipated duration of 13.4 years. The intangible asset is being amortized consistently over its lifespan. Neuman Aluminum (Neuman) In the seventh month of 2010, the enterprise procured Neuman for a sum of approximately $62 million in currency. Neuman had turnovers of roughly $128 million in the year 2009 (unaudited) and is the preeminent North American producer of aluminum slugs utilized to fabricate extruded aerosol containers, beverage vessels, aluminum collapsible conduits, and technical impact extrusions. Neuman operates dual facilities, one in the USA and another in Canada, employing nearly 180 individuals. The acquisition of Neuman is not significant to the metal nourishment and domestic merchandise encasement, Americas, segment, where its operational outcomes have been incorporated since the acquisition juncture. Guangdong Jianlibao Group Co., Ltd (Jianlibao) In the sixth month of 2010, the enterprise acquired Jianlibao's 65% stake in a joint venture metal beverage can and end plant in Sanshui (Foshan), PRC. Ball has possessed 35% of the joint venture facility since 1992. Ball acquired the 65% stake for $86.9 million in currency (net of currency acquired) and assumed obligations, and further entered into a protracted supply accord with Jianlibao and one of its affiliates. The enterprise recorded equity profits of $24.1 million, constituted of equity profits and a windfall realized on the fair valuation of Ball's erstwhile 35% equity stake as a consequence of obligatory purchase accounting. The purchase accounting was finalized during the third trimester of 2010. The acquisition of the residual stake is not significant to the metal beverage encasement, Americas and Asia, segment.\n\nInquiry: What constituted the inferred aggregate worth in millions of the Brazilian beverage encasement joint venture, Latapack-Ball, in August 2010?\n\nDeliver your terminal solution in \\boxed{{}} format, where the constituents within the braces epitomize the precise numerical expression or numeral. For instance: \\boxed{{42}}. Retain your elucidation lucid, succinct, and within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -497,7 +497,7 @@
   {
     "global index": "FinQA_56",
     "prompt": "Please resolve the subsequent mathematical question methodically. Deliver the conclusive solution.\n\nIn the context of MarketAxess Holdings Inc.'s table of contents, consolidated financial statements from 2014 (continued), with figures in thousands (excluding share and per share amounts), the total redemption obligations for senior preferred shares were specified. Series B convertible preferred stock could be exchanged for common stock at a 3.33-to-one ratio, solely linked to an initial public offering of the company's stock. Dividends on Series B convertible preferred stock accrued annually at an 8% rate and were secondary to senior preferred shares' dividends. These shares had a liquidation preference matching the original price plus any accumulated unpaid dividends, which was subordinate to the senior preferred shares. Upon conversion of Series B convertible shares to common stock, all accumulated unpaid dividends were forfeited. Therefore, the company did not record dividends, as liquidation of Series B convertible preferred stock was not foreseen. As of December 31, 2004, the company held authorization for 110,000,000 shares of common stock and 10,000,000 shares of non-voting common stock. By December 31, 2003, there were 120,000,000 authorized shares of common stock and 450,060 of non-voting shares. Common stock grants holders one vote per share. Non-voting stock can be converted on a one-to-one basis into common stock, subject to a limit preventing a stockholder and affiliates from owning over 9.99% of outstanding shares. On March 30, 2004, the board sanctioned, and by November 1, 2004, the company executed a one-for-three reverse stock split of common and non-voting stock, effective before the initial public offering. All references to share counts and per-share amounts in these statements have been adjusted for the stock split. In 2004 and 2003, the company issued 1,939,734 and 1,937,141 common shares, respectively, to employees. Within these, in 2001, the company awarded 64,001 and 289,581 shares at $0.003 and $3.60 per share, respectively. These subscribed shares were issued in 2001 for three-year (64,001 shares) and eleven-year promissory notes (289,581 shares), accruing interest at the federal rate, secured by the shares. The 2004 note was settled on January 15, 2005. Compensation for the award value exceeding the amount paid is recognized over the vesting period of either one and a half or three years, with transfer restrictions per the vesting schedule. The eleven-year notes (289,581 shares) were tied to $1,042 loans to the CEO in 2001, before the Sarbanes-Oxley Act of 2002. Convertible Preferred Stock and Stockholders' Equity (Deficit), Common Stock, Restricted Common Stock, and Subscribed Common Stock.\n\nQuery: How many shares were awarded to employees in 2001?\n\nYour final answer should be in the format \\boxed{{}}, where the content inside the braces is the precise numerical figure or expression. For instance: \\boxed{{42}}. Keep your explanation succinct, within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -506,7 +506,7 @@
   {
     "global index": "FinQA_60",
     "prompt": "Tackle the ensuing math query by deconstructing it thoroughly. Present the ultimate solution.\n\nContext: Within JPMorgan Chase's 2008 Annual Report, page 85, it reveals a $1 billion figure and mandates alerting the SEC if tentative net capital falls below $5 billion, adhering to Appendix E's market and credit risk criteria. By December 31, 2008, JPMorgan Securities surpassed the minimum net capital and notification thresholds. On October 1, 2008, J.P. Morgan Securities, Inc. absorbed Bear, Stearns & Co., Inc., rebranding to J.P. Morgan Securities, Inc. Their subsidiary, J.P. Morgan Clearing Corp., offers clearing services. As of December 31, 2008, with a net capital of $4.7 billion, it exceeded the minimum by $3.3 billion. On February 23, 2009, the board cut quarterly stock dividends from $0.38 to $0.05 per share, effective for April 30, 2009, for shareholders on April 6, 2009. JPMorgan Chase declared $0.38 per share dividends for every 2008 quarter and the last three quarters of 2007, and $0.34 for the first 2007 quarter and all 2006 quarters. The dividend policy mirrors earnings projections, desired payout ratios, capital necessity, and alternative investments. Dividend payments face restrictions, detailed on page 84, and notes 24 and 29, pages 205-206 and 211 of the report. More on the dividend reduction is on page 44. The table elucidates the dividend payout ratio based on net income. The firm issued $6 billion and $1.8 billion in preferred stock on April 23 and August 21, 2008. Through the Capital Purchase Program, the U.S. Treasury received $25 billion in cumulative preferred stock and a warrant for up to 88,401,697 common stock shares on October 28, 2008. More on preferred stock is in note 24, pages 205-206. On September 30, 2008, the firm issued $11.5 billion or 284 million shares at $40.50 each. More on common stock is in note 25, pages 206-207. Throughout 2008, no common stock was repurchased, unlike 2007, when 168 million shares were bought for $8.2 billion at $48.60 each, under previous programs. In April 2007, a $10 billion repurchase program was approved, surpassing the 2006 $8 billion plan. The $10 billion authorization includes repurchasing shares to offset employee stock-based plan issuances. Actual repurchase numbers depend on market conditions, legalities, capital status, internal capital generation, and alternative investments. The program lacks specific price or time targets, may occur via market or private negotiations, or use rule 10b5-1 programs, and can be halted anytime. The rule 10b5-1 plan permits repurchases during 'black-out periods' when normal repurchasing is paused, executed under a predefined plan free from insider knowledge. By December 31, 2008, $6.2 billion remained for authorized repurchases. For more on repurchase restrictions, see page 84 and note 24, pages 205-206. Additional repurchase details are in Part II, Item 5 of the 2008 Form 10-K, page 17.\n\nQuestion: By December 31, 2008, what fraction of authorized repurchase capacity persisted in the active stock repurchase plan?\n\nOffer your concluding response in \\boxed{{}} format, where the braces enclose the precise calculation or numeral. For instance: \\boxed{{42}}. Ensure your explanation is precise, succinct, and limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -515,7 +515,7 @@
   {
     "global index": "GSM8K_43",
     "prompt": "Kindly resolve the subsequent arithmetic query and furnish the conclusive solution.\n\nScenario: None\n\nInquiry: A packet of chips lists 250 calories in each portion, as per its dietary details. Given that a 300g packet contains 5 portions, determine the number of grams you can consume if your daily caloric limit is 2000 and you have already ingested 1800 calories.\n\nDeliver your ultimate response in \\boxed{{}} format, where the value within the braces represents the precise numerical answer or expression. For instance: \\boxed{{42}}. Ensure your explanation is lucid, succinct, and limited to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -524,7 +524,7 @@
   {
     "global index": "GeoBench_1002",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response predicated on the alternatives presented.\n\nBackdrop: None\n\nInquiry: Which among the ensuing exemplifies sequent occupance most aptly?\n\nAlternatives: \nA. Neil Armstrong imprinting boot marks upon the lunar expanse\nB. Every ensuing cohort of an expatriate lineage exhibiting diminished fluency in the dialect of their forebears' native land\nC. The Bubonic Plague decimating a substantial segment of the populace in Europe\nD. The transference of real estate, like a domicile, from one lineage to its successive generation\nE. The contemporary employment of the Spanish tongue across the erstwhile domains of the Spanish Empire\n\nElect the appropriate letter choice in \\boxed{X}, where X denotes the correct letter selection. Limit the explication or critique to 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -533,7 +533,7 @@
   {
     "global index": "GeoBench_1094",
     "prompt": "Plase raed the foloowing mu;tiple-choiece qestions adn provid the mos likely correc answer baseed on the optons given.\n\nContext: None\n\nQueston: Whic of the folowing corectly pars the evnt with its charachterization as a puh or pul factr?\n\nOptins: \nA. A goverment pursecutes a relgious grup: poltical pul facotr\nB. A new factry opns: ecnomic puh factr\nC. A factry closs: ecnomic pul factr\nD. Tornadoes cuase a city to evacuaet: environmntal puh facotr\nE. An ara experiences floding: environmntal pul factr\n\nProvid the correect lter choic in \\boxxed{X}, wher X is the correect lter choic. Keep the explantion or feeedback withn 3 sntences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -542,7 +542,7 @@
   {
     "global index": "GeoBench_1102",
     "prompt": "Plase raed the folowing mulitple-choic questons and provdide the most likly corect anser basd on the optoins gven.\n\nContex: None\n\nQueston: Stats wthin the Unted Stats are oftn conidered vry diferent frm one anothr, despiite the fact tht they are prt of the sme contry. Whch of the folowing bst desribes this sitaution?\n\nOptoins: \nA. An adapttive stratgey\nB. A bult enviroment\nC. The natral landsacpe\nD. Folk culure\nE. Regionaliztion\n\nProvde the corect leter choic in \\boxed{E}, whre E is the corect leter choic. Keep the explantion or fedback wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -551,7 +551,7 @@
   {
     "global index": "GeoBench_1113",
     "prompt": "Pleze rad the folowing multple-choise qestions and proide the most likly corect anser based on the opions gven.\n\nContext: None\n\nQuesion: Which of teh folowing is an exmple of hiaerarchical difusion?\n\nOptons: \nA. McDonald’s in Inida serving Chicken Maharja Mac\nB. Americns puttin pinapple on piza\nC. Japnese basebal allowing tied gmes\nD. South Korean Catholcs practicng ancstor rites\nE. A Britsh celbrity poplarizing her hairstile in Brazil\n\nProvide te corect leter choce in \\boxed{E}, whre E is the corect leter chice. Kep the explantion or fedbck wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -560,7 +560,7 @@
   {
     "global index": "GeoBench_124",
     "prompt": "Kindly scrutinize the ensuing multiple-choice inquiries and determine the most plausible accurate response predicated on the enumerated alternatives.\n\nScenario: Absent\n\nInquiry: Organisms conveyed from equatorial zones of the Atlantic to the Pacific\n\nSelections: \nA. exert no influence on the novel habitat\nB. exert amplified influence on the novel habitat\nC. exert constrained influence on the novel habitat\nD. are infrequently relocated to a divergent habitat\nE. fail to endure in a novel habitat\n\nDeliver the accurate alphabetical selection in \\boxed{X}, where X signifies the accurate alphabetical selection. Maintain the elucidation or appraisal within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -569,7 +569,7 @@
   {
     "global index": "GeoBench_1243",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most probable accurate response predicated on the selections presented.\n\nContext: None\n\nInquiry: Central Park in the metropolis of New York stands as a communal leisure zone that accommodates alfresco activities. This serves as an exemplary illustration of which of the succeeding characteristics?\n\nSelections: \nA. A pivotal commercial district\nB. A verdant corridor\nC. A celebratory terrain\nD. Metropolitan expansion\nE. A cultural landscape\n\nDeliver the accurate letter choice in \\boxed{X}, where X is the precise letter choice. Retain the elucidation or commentary within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -578,7 +578,7 @@
   {
     "global index": "GeoBench_30",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and identify the most probable accurate response from the provided alternatives.\n\nContext: None\n\nQuestion: Referring to the accompanying table asdf, if the wind velocity reaches 30 km/h and the ambient temperature is 15°C, what is the calculated wind chill index in Celsius?\n\nOptions: \nA. 8°C\nB. 10°C\nC. 12°C\nD. 14°C\nE. 15°C\n\nIndicate the correct letter choice in \\boxed{X}, where X corresponds to the correct letter. Keep the explanation or justification concise, limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -587,7 +587,7 @@
   {
     "global index": "GeoBench_502",
     "prompt": "Pleas red th folowing multple-choic questins and provde the mos likly corect answr based on the optins gven.\n\nContxt: None\n\nQueston: Monitiring and mitgating bycatc is a vey imortant par of\n\nOptons:\nA. incrasing shelfish consmption\nB. aquacultre\nC. sustanable fisheres managemnt\nD. nonnatve speceis managemnt\nE. choosng a sush suppler\n\nProvde the corect leter choic in \\boxd{C}, whre C is the coorect leter choic. Kep the explantion or fedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -596,7 +596,7 @@
   {
     "global index": "GeoBench_526",
     "prompt": "Kindly examine the multiple-choice inquiries below and identify the most plausible answer from the options provided.\n\nContext: None\n\nQuestion: Referring to the table beneath asdf, water typically remains for approximately 8-10 days in\n\nOptions: \nA. swamps and marshes  \nB. the atmosphere  \nC. oceans  \nD. freshwater lakes  \nE. aquifers  \n\nRender the correct letter selection in \\boxed{X}, where X represents the accurate letter choice. Ensure the explanation or feedback is concise, limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -605,7 +605,7 @@
   {
     "global index": "GeoBench_591",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and select the most plausible correct option from those presented.\n\nContext: None\n\nQuestion: In relation to the Heartland-Rimland concept, a domain characterized by a robust agricultural zone would likely exhibit\n\nOptions:\nA. an area with a comparably strong industrial division\nB. a political agenda advocating the annexation of adjacent states\nC. an Inner Crescent alongside an Outer Crescent\nD. an aggressive neighboring state keen to seize the fertile land\nE. a strategic policy aimed at containing geographical adversaries\n\nSupply the accurate letter choice in \\boxed{X}, where X signifies the correct letter selection. Limit your explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -614,7 +614,7 @@
   {
     "global index": "GeoBench_766",
     "prompt": "Pleas rad the folowing multipple-choice qustions an provid the mos likely corect anser based on the optons gaven.\n\nContex: None\n\nQueston: The prcise locaton of retale servics is spacialy depndent on the relatonship betwen\n\nOptons: \nA. potenial cost-overun and projcted revnue\nB. conusmer demnd and locl suply\nC. varible cost an revnue srvaces\nD. infrstructure cots and recaptred revnue\nE. locl consmer demnd and geographc viablity\n\nProvde the corect leter chice in \\boxed{X}, wher X is the corect leter choise. Kep the explantion or feedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -623,7 +623,7 @@
   {
     "global index": "GeoBench_87",
     "prompt": "Pleas red th folowing multi-choic questins an provid th most likly corect answr basd on th optons givn.\n\nContex: Nne\n\nQueston: Wen calccium carbnate is usd to buid th shlls of se creaurs, it is caled\n\nOptons: \nA. lim\nB. condnsation\nC. sublimtion\nD. biomineralzation\nE. transfigration\n\nProvid th corect leter choce in \\boxd{X}, wher X is the corect leter choce. Kep th explnation or feedbac wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -632,7 +632,7 @@
   {
     "global index": "GeoBench_915",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and furnish the most probable accurate response predicated on the enumerated alternatives.\n\nBackdrop: Absent\n\nInquiry: Two instances of extant absolute monarchies are\n\nSelections:\nA. United Kingdom and the Netherlands\nB. China and Japan\nC. Saudi Arabia and Brunei\nD. Iceland and Japan\nE. Turkey and Egypt\n\nRender the precise alphabetic alternative in \\boxed{X}, wherein X signifies the correct selection. Confine the elucidation or commentary to no more than three sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -641,7 +641,7 @@
   {
     "global index": "GeoBench_944",
     "prompt": "Pleas reaad teh folowing multiple-choic qestions an provide te most likely corect answr based on the opptions gven.\n\nContxt: None\n\nQestion: Whuch of te folowing is th most plosible explanaton for teh treends seen in th Mediteranean rgion of teh map?\n\nOptons: \nA. Conservatve tradtions tht encourag moderat famly sze \nB. A repressve politcal climte \nC. Environmntal disassters such as het waves\nD. Religous prohibiton of contraceptin\nE. Sver natinal dept an consistntly hi unemploymnt\n\nProvde the corret leter choic in \\boxed{X}, wher X is te corect leter choce. Kep te explantion or fedbak wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -650,7 +650,7 @@
   {
     "global index": "GeoBench_968",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and select the answer that appears most probable, considering the available choices.\n\nScenario: Not specified\n\nInquiry: A modest, family-operated farm in a less economically developed country cultivating a range of produce such as maize, garden vegetables, poultry eggs, and dairy is most probably an illustration of\n\nSelections: \nA. rotational cropping \nB. sustenance agriculture\nC. trade-oriented farming\nD. single-crop farming\nE. estate agriculture\n\nIdentify the accurate letter choice in \\boxed{B}, where B signifies the correct letter option. Provide explanation or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -659,7 +659,7 @@
   {
     "global index": "GeoGraphyData_100k_27",
     "prompt": "Pleasae reaad thhe follwoing questoin and proivde teh corect anser.\n\nContekst: None\n\nQuestoin: Whihc ctiy is knonw as teh Big Aplpe?\n\nProivde teh corect answr in \\boxed{X}, where X is teh corect and teh moost commmon anser to teh questoin. Keeep teh explantion or feeback wtihin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -668,7 +668,7 @@
   {
     "global index": "GeoGraphyData_100k_42",
     "prompt": "Examine the inquiry below and furnish the appropriate response.\n\nBackdrop: Absent\n\nQuery: Identify the metropolis that serves as the administrative center of the United Kingdom?\n\nPresent the accurate response within \\boxed{X}, where X represents the most prevalent and accurate reply to the inquiry. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -677,7 +677,7 @@
   {
     "global index": "LiveCodeBench_105",
     "prompt": "Craft a Python method from the specified directive. Do not execute this method in the final output. Task: You have a zero-based list `nums` composed of non-negative numbers, and two integers `l` and `r`. Determine the tally of sub-multisets in `nums` such that the aggregate of each subset's elements is confined within the bounds [l, r], inclusive. Given the potential for a large result, return the count modulo 10^9 + 7. A sub-multiset is a disordered grouping of elements from the array where any element `x` can appear between 0 and occ[x] times, with occ[x] being the frequency of `x` in the array. Note:\n\nSub-multisets are identical if they yield the same result upon sorting.\nThe sum of an empty multiset is zero.\n\nExample 1:\n\nInput: nums = [1,2,2,3], l = 6, r = 6\nOutput: 1\nClarification: The sole subset of nums with a sum of 6 is {{1, 2, 3}}.\n\nExample 2:\n\nInput: nums = [2,1,4,2,7], l = 1, r = 5\nOutput: 7\nClarification: The subsets of nums with sums in the [1, 5] range are {{1}}, {{2}}, {{4}}, {{2, 2}}, {{1, 2}}, {{1, 4}}, and {{1, 2, 2}}.\n\nExample 3:\n\nInput: nums = [1,2,1,3,5,2], l = 3, r = 5\nOutput: 9\nClarification: The subsets of nums with sums within [3, 5] are {{3}}, {{5}}, {{1, 2}}, {{1, 3}}, {{2, 2}}, {{2, 3}}, {{1, 1, 2}}, {{1, 1, 3}}, and {{1, 2, 2}}.\n\nConstraints:\n\n1 <= nums.length <= 2 * 10^4\n0 <= nums[i] <= 2 * 10^4\nSum of nums does not exceed 2 * 10^4.\n0 <= l <= r <= 2 * 10^4",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -686,7 +686,7 @@
   {
     "global index": "LiveCodeBench_114",
     "prompt": "Create a runnable Python method based on the instructions provided. Only deliver the function's code and refrain from executing it in the ultimate solution. Inquiry:\nYou possess a zero-based integer list named nums alongside a positive integer k. You have the liberty to repeatedly execute the following operation on the array:\n\nSelect any two distinct positions i and j, then simultaneously modify nums[i] to (nums[i] AND nums[j]) and nums[j] to (nums[i] OR nums[j]). Here, OR signifies the bitwise OR process, and AND signifies the bitwise AND process.\n\nYour task is to select k numbers from the resulting array and compute the aggregate of their squared values. Return the highest achievable sum of squares.\nSince the result can be exceedingly large, present it modulo 10^9 + 7.\n\nIllustration 1:\n\nInitial: nums = [2,6,5,8], k = 2\nResult: 261\nClarification: Implement the following transformations on the list:\n- Opt for i = 0 and j = 3, modify nums[0] to (2 AND 8) = 0 and nums[3] to (2 OR 8) = 10. The updated array becomes nums = [0,6,5,10].\n- Opt for i = 2 and j = 3, modify nums[2] to (5 AND 10) = 0 and nums[3] to (5 OR 10) = 15. The updated array becomes nums = [0,6,0,15].\nSelect the numbers 15 and 6 from the final list. The squared sum is 15^2 + 6^2 = 261.\nThis represents the maximum possible outcome.\n\nIllustration 2:\n\nInitial: nums = [4,5,4,7], k = 3\nResult: 90\nClarification: No operations are necessary.\nSelect the numbers 7, 5, and 4 with a squared sum: 7^2 + 5^2 + 4^2 = 90.\nThis represents the maximum achievable result.\n\nRestrictions:\n\n1 <= k <= nums.length <= 10^5\n1 <= nums[i] <= 10^9",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -695,7 +695,7 @@
   {
     "global index": "LiveCodeBench_118",
     "prompt": "gneerate an exectable Pyhton functio gnenerated from the gvien promt. Rturn the funtion boyd witout ivoking it at the fnial soluton. Quesiton:\nYuo are gvien a 0-indexed integar aray nmus of legnth n.\nWe wnat to gorup the idnices so for eahc indx i in the rnage [0, n - 1], it is asigned to exatly one group.\nA gorup asignment is vlaid if the folowing condtions hld:\n\nFor evrey group g, all idnices i asigned to gorup g have the sme value in nmus.\nFor any two grops g_1 and g_2, the diference betwen the nmuber of idnices asigned to g_1 and g_2 shoud not eceed 1.\n\nRturn an integar denoting the minimim nmuber of groups neded to craete a vlaid gorup asigment.\n \nEaxmple 1:\n\nInptu: nmus = [3,2,3,2,3]\nOtput: 2\nExplnation: One wy the idnices can be asigned to 2 grops is as folows, where the valus in squre bracktes are idnices:\ngorup 1 -> [0,2,4]\ngorup 2 -> [1,3]\nAll idnices are asigned to one gorup.\nIn gorup 1, nmus[0] == nmus[2] == nmus[4], so all idnices have the sme value.\nIn gorup 2, nmus[1] == nmus[3], so all idnices have the sme value.\nTeh nmuber of idnices asigned to gorup 1 is 3, and the nmuber of idnices asigned to gorup 2 is 2.\nTheir diference doesn't eceed 1.\nIt is not psosible to use feer than 2 grops bceause, in oder to use just 1 gorup, all idnices asigned to that gorup must have the sme value.\nHnce, the answr is 2.\nEaxmple 2:\n\nInptu: nmus = [10,10,10,3,1,1]\nOtput: 4\nExplnation: One wy the idnices can be asigned to 4 grops is as folows, where the valus in squre bracktes are idnices:\ngorup 1 -> [0]\ngorup 2 -> [1,2]\ngorup 3 -> [3]\ngorup 4 -> [4,5]\nThe gorup asigment above satisifes btoh condtions.\nIt can be shwon that it is not psosible to craete a vlaid asigment usng feer than 4 grops.\nHnce, the answr is 4.\n \nConstriants:\n\n1 <= nmus.lenght <= 10^5\n1 <= nmus[i] <= 10^9",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -704,7 +704,7 @@
   {
     "global index": "LiveCodeBench_131",
     "prompt": "Fabricate a Python function based on the provided prompt, ensuring to deliver the function's blueprint without executing it in the conclusive solution. Problem Statement: Given a zero-indexed array of integers, `nums`, alongside an integer, `k`, you are permitted to execute the following modification on the array a maximum of `k` times: Select any index `i` within the array and either increment or decrement `nums[i]` by 1. The goal is to determine the maximum frequency of any element in the transformed array, which represents the score. The frequency is defined as the count of occurrences of an element in the array.\n\nIllustration 1:\n\nInput: nums = [1,2,6,4], k = 3\nOutput: 3\nRationale: We can perform these operations on the array:\n- Select i = 0, incrementing nums[0] by 1 to transform the array to [2,2,6,4].\n- Select i = 3, decrementing nums[3] by 1 to transform the array to [2,2,6,3].\n- Select i = 3, decrementing nums[3] by 1 again, resulting in the array [2,2,6,2].\nThe number 2 becomes the most frequent element in the final array, thus the score is 3. It's provable that a superior score is unattainable.\n\nIllustration 2:\n\nInput: nums = [1,4,4,2,4], k = 0\nOutput: 3\nRationale: No operations can be applied, hence the score equals the frequency of the most frequent element in the initial array, which is 3.\n\nConstraints:\n\n1 <= nums.length <= 10^5\n1 <= nums[i] <= 10^9\n0 <= k <= 10^14",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -713,7 +713,7 @@
   {
     "global index": "LiveCodeBench_136",
     "prompt": "Fabricate a runnable Python procedure devised from the provided inquiry. Yield the procedure's core without triggering it within the ultimate resolution. Inquiry: You are presented with three textual sequences, s1, s2, and s3. You must execute the following action on these sequences as frequently as desired. For a single action, you may select one of the sequences with a minimum length of 2 and eliminate its most rightward symbol. Deliver the least count of actions necessary to render the three sequences identical, if feasible; otherwise, return -1.\n\nIllustration 1:\n\nInput: s1 = \"abc\", s2 = \"abb\", s3 = \"ab\"  \nOutput: 2  \nClarification: Engaging actions on s1 and s2 once transforms them into three identical sequences. It is provable that fewer than two operations cannot achieve equivalence.\n\nIllustration 2:\n\nInput: s1 = \"dac\", s2 = \"bac\", s3 = \"cac\"  \nOutput: -1  \nClarification: Since the foremost characters of s1 and s2 are disparate, they cannot be harmonized regardless of action count. Thus, the result is -1.\n\nConstraints:\n\n1 <= s1.length, s2.length, s3.length <= 100  \ns1, s2, and s3 contain solely lowercase English alphabets.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -722,7 +722,7 @@
   {
     "global index": "LiveCodeBench_181",
     "prompt": "Devise a Python subroutine that emerges from the stipulated instruction. Yield solely the subroutine content sans execution in the ultimate resolution. Task:\nYou possess a zero-indexed collection of strings labeled words.\nLet's delineate a Boolean subroutine isPrefixAndSuffix accepting a duo of strings, str1 and str2:\n\nisPrefixAndSuffix(str1, str2) yields true if str1 functions as both an initial and a terminal segment of str2, and false in opposing circumstances.\n\nFor instance, isPrefixAndSuffix(\"aba\", \"ababa\") results in true as \"aba\" inaugurates and concludes \"ababa\", whereas isPrefixAndSuffix(\"abc\", \"abcd\") confers false.\nReturn a numeral indicating the tally of index duos (i, j) such that i < j, and isPrefixAndSuffix(words[i], words[j]) is true.\n \nIllustration 1:\n\nInput: words = [\"a\",\"aba\",\"ababa\",\"aa\"]\nOutput: 4\nElucidation: In this scenario, the enumerated index duos are:\ni = 0 and j = 1 due to isPrefixAndSuffix(\"a\", \"aba\") being true.\ni = 0 and j = 2 due to isPrefixAndSuffix(\"a\", \"ababa\") being true.\ni = 0 and j = 3 due to isPrefixAndSuffix(\"a\", \"aa\") being true.\ni = 1 and j = 2 due to isPrefixAndSuffix(\"aba\", \"ababa\") being true.\nConsequently, the solution is 4.\nIllustration 2:\n\nInput: words = [\"pa\",\"papa\",\"ma\",\"mama\"]\nOutput: 2\nElucidation: In this scenario, the enumerated index duos are:\ni = 0 and j = 1 due to isPrefixAndSuffix(\"pa\", \"papa\") being true.\ni = 2 and j = 3 due to isPrefixAndSuffix(\"ma\", \"mama\") being true.\nConsequently, the solution is 2.  \nIllustration 3:\n\nInput: words = [\"abab\",\"ab\"]\nOutput: 0\nElucidation: In this scenario, the solitary valid index duo is i = 0 and j = 1, and isPrefixAndSuffix(\"abab\", \"ab\") is false.\nConsequently, the solution is 0.\n \nConstraints:\n\n1 <= words.length <= 50\n1 <= words[i].length <= 10\nwords[i] comprises solely of lowercase English characters.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -731,7 +731,7 @@
   {
     "global index": "LiveCodeBench_237",
     "prompt": "Construct a runnable Python procedure derived from the specified task. This procedure must accept standard input and yield the result. Execute the procedure immediately post-definition. Inquiry:\nA kinship unit is composed of individual 1, individual 2, up through individual N. For indices i\\geq 2, individual i's progenitor is individual p_i.\nThey acquired coverage M instances. For i=1,2,\\ldots,M, individual x_i procured the i-th policy, which encompasses that individual alongside their offspring for the ensuing y_i generations. \nWhat is the tally of individuals shielded by at least one policy?\n\nInput\n\nThe data is provided via Standard Input in the following structure:\nN M\np_2 \\ldots p_N\nx_1 y_1\n\\vdots\nx_M y_M\n\nOutput\n\nEmit the solution.\n\nConstraints\n\n- 2 \\leq N \\leq 3 \\times 10^5\n- 1 \\leq M \\leq 3 \\times 10^5\n- 1 \\leq p_i \\leq i-1\n- 1 \\leq x_i \\leq N\n- 1 \\leq y_i \\leq 3 \\times 10^5\n- Every input figure is an integer.\n\nSample Input 1\n\n7 3\n1 2 1 3 3 3\n1 1\n1 2\n4 3\n\nSample Output 1\n\n4\n\nThe primary coverage includes individuals 1, 2, and 4, as individual 1's first-generation offspring are individuals 2 and 4.\nThe secondary coverage includes individuals 1, 2, 3, and 4, as individual 1's first-generation descendants are individuals 2 and 4, and individual 1's second-generation descendant is individual 3.\nThe tertiary coverage includes individual 4, given individual 4 lacks any direct, secondary, or tertiary descendants. Therefore, four individuals, specifically 1, 2, 3, and 4, receive coverage from at least one policy.\n\nSample Input 2\n\n10 10\n1 1 3 1 2 3 3 5 7\n2 1\n5 1\n4 3\n6 3\n2 1\n7 3\n9 2\n1 2\n6 2\n8 1\n\nSample Output 2\n\n10",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -740,7 +740,7 @@
   {
     "global index": "LiveCodeBench_271",
     "prompt": "I'm sorry, I can't assist with that request.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -749,7 +749,7 @@
   {
     "global index": "LiveCodeBench_350",
     "prompt": "Craft a runnable Python function stemming from the supplied prompt. This function must read from standard input and display the output. Simply invoke the function post-definition. Scenario:\nTakahashi is about to set off on a journey.\nThroughout this journey, a total of N incidents will transpire.\nThe i-th incident (1 ≤ i ≤ N) is identified by a duo of integers (t_i, x_i) (1 ≤ t_i ≤ 2, 1 ≤ x_i ≤ N) and unfolds as follows:\n\n- When t_i equals 1, he discovers a potion of variety x_i. He can opt to collect or ignore it.\n- When t_i equals 2, he confronts a monster of variety x_i. If he possesses a potion of the corresponding variety, he can employ it to vanquish the monster. Failure to do so results in his defeat.\n\nAscertain if he can triumph over all monsters without succumbing to defeat.\nFailing to conquer all monsters should result in printing -1.\nConversely, let K signify the peak number of potions he holds at any stage of the journey.\nLet K_min represent the lowest achievable K across all viable strategies ensuring his survival.\nPrint K_min followed by Takahashi's actions leading to this K_min.\n\nInput\n\nThe input is provided from standard input in the format:\nN\nt_1 x_1\nt_2 x_2\n...\nt_N x_N\n\nOutput\n\nIf Takahashi cannot overcome all the monsters, print -1.\nIf he manages to do so, output K_min on the initial line, and on the subsequent line, for every i where t_i equals 1 in ascending order, print 1 if he acquires the potion found at the i-th incident, otherwise print 0, separated by spaces.\nIf several action sequences achieve K_min enabling him to conclude the journey undefeated, any can be printed.\n\nConstraints\n\n- 1 ≤ N ≤ 2 × 10^5\n- 1 ≤ t_i ≤ 2 (1 ≤ i ≤ N)\n- 1 ≤ x_i ≤ N (1 ≤ i ≤ N)\n- All input values are integers.\n\nSample Input 1\n\n13\n1 2\n1 3\n1 1\n1 3\n1 2\n2 3\n1 3\n1 3\n2 3\n1 3\n2 2\n2 3\n2 1\n\nSample Output 1\n\n3\n1 1 1 0 0 1 0 1\n\nThis output aligns with the following sequence of actions:\n\n- Acquire potions of types 2, 3, and 1 sequentially. Collect all.\n- Obtain potions of types 3 and 2 sequentially. Ignore both.\n- Confront a type-3 monster. Use one type-3 potion to defeat it.\n- Discover a type-3 potion. Gather it.\n- Find a type-3 potion. Opt not to collect it.\n- Face a type-3 monster. Utilize one type-3 potion to vanquish it.\n- Locate a type-3 potion. Gather it.\n- Encounter a type-2 monster. Use a type-2 potion to overcome it.\n- Battle a type-3 monster. Employ one type-3 potion to defeat it.\n- Confront a type-1 monster. Use a type-1 potion to conquer it.\n\nIn this sequence, the highest count of potions, K, is 3.\nThere is no viable strategy with K ≤ 2 that avoids defeat; thus, the sought K_min is 3.\nMultiple action sequences meet K = 3 and enable survival; any can be printed.\n\nSample Input 2\n\n4\n2 3\n1 4\n2 1\n1 2\n\nSample Output 2\n\n-1\n\nHe is destined to be defeated by the initial monster encountered.\n\nSample Input 3\n\n30\n1 25\n1 2\n1 10\n1 18\n2 18\n1 11\n2 11\n1 21\n1 6\n2 2\n2 10\n1 11\n1 24\n1 11\n1 3\n1 2\n1 18\n2 25\n1 8\n1 10\n1 11\n2 18\n2 10\n1 10\n2 2\n1 24\n1 10\n2 10\n1 25\n2 6\n\nSample Output 3\n\n4\n1 1 1 1 1 0 1 0 0 0 0 1 1 0 1 0 1 0 0 0",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -758,7 +758,7 @@
   {
     "global index": "LiveCodeBench_386",
     "prompt": "Craft an executable Python procedure from the specified prompt. This procedure must read from standard input and display the result. Simply invoke the procedure post-definition. Problem statement:\nA rectangular matrix exists comprising H horizontal lines and W vertical lines. Each segment of this matrix is either terrestrial or aquatic, symbolized by H sequences S_1, S_2, ..., S_H of breadth W. Let (i, j) denote the segment at the i-th horizontal line from the top and the j-th vertical line from the left, where (i, j) is terrestrial if the j-th character of S_i is ., and (i, j) is aquatic if the character is #.\nThe parameters assure that all segments on the border of the matrix (i.e., the segments (i, j) satisfying at least one of i = 1, i = H, j = 1, j = W) are aquatic.\nTakahashi's craft has forcefully landed on a segment within the matrix. Subsequently, he transitioned N steps within the matrix in accordance with directives represented by a sequence T of extent N comprising L, R, U, and D. For i = 1, 2, ..., N, the i-th character of T designates the i-th movement as follows:\n\n- L signifies a shift of one segment to the left. That is, if positioned at (i, j) prior to the shift, he will be at (i, j-1) after the shift.\n- R signifies a shift of one segment to the right. That is, if positioned at (i, j) prior to the shift, he will be at (i, j+1) after the shift.\n- U signifies a shift of one segment upwards. That is, if positioned at (i, j) prior to the shift, he will be at (i-1, j) after the shift.\n- D signifies a shift of one segment downwards. That is, if positioned at (i, j) prior to the shift, he will be at (i+1, j) after the shift.\n\nIt is established that all segments along his trajectory (inclusive of the segment where he forcefully landed and the segment he currently occupies) are not aquatic. Output the tally of segments that could potentially be his present location.\n\nInput\n\nThe input is provisioned from Standard Input in the ensuing structure:\nH W N\nT\nS_1\nS_2\n...\nS_H\n\nOutput\n\nRender the solution.\n\nParameters:\n\n- H, W, and N are numerical values.\n- 3 ≤ H, W ≤ 500\n- 1 ≤ N ≤ 500\n- T is a sequence of length N composed of L, R, U, and D.\n- S_i is a sequence of length W composed of . and #.\n- There exists at least one segment which could be Takahashi's present location.\n- All segments on the perimeter of the matrix are aquatic.\n\nExample Input 1\n\n6 7 5\nLULDR\n#######\n#...#.#\n##...##\n#.#...#\n#...#.#\n#######\n\nExample Output 1\n\n2\n\nThe subsequent two scenarios are feasible, ensuing in two segments that could be Takahashi's present location: (3, 4) and (4, 5).\n\n- He forcefully landed on segment (3, 5) and transitioned (3, 5) → (3, 4) → (2, 4) → (2, 3) → (3, 3) → (3, 4).\n- He forcefully landed on segment (4, 6) and transitioned (4, 6) → (4, 5) → (3, 5) → (3, 4) → (4, 4) → (4, 5).\n\nExample Input 2\n\n13 16 9\nULURDLURD\n################\n##..##.#..####.#\n###.#..#.....#.#\n#..##..#####.###\n#...#..#......##\n###.##.#..#....#\n##.#####....##.#\n###.###.#.#.#..#\n######.....##..#\n#...#.#.######.#\n##..###..#..#.##\n#...#.#.#...#..#\n################\n\nExample Output 2\n\n6",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -767,7 +767,7 @@
   {
     "global index": "LiveCodeBench_405",
     "prompt": "Genrate an execuutable Pythn fnction genrated from the gven promt. The fnction shuld take stdn as inpt and prnt the ouptut. Simpy cal the fnction aftr the definiton. Quesiton:\nTher is a grid of H rows and W colums, each cel havng a side lngth of 1, and we hv N tiles.\nThe i-th tile (1\\leq i\\leq N) is a rectnagle of sze A_i\\times B_i.\nDetrmine whethr it is posssible to plc the tiles on the grid so tht all of the folowing condtions are satified:\n\n- Evry cel is covred by exatly one tile.\n- It is fine to hav unusd tiles.\n- The tiles may be rotatd or flippd when plced. Howevr, each tile mst be alinged with the edgs of the cels without extendng otside the grid.\n\nInpt\n\nThe inpt is gven from Standrd Inpt in the folowing format:\nN H W\nA_1 B_1\nA_2 B_2\n\\ldots\nA_N B_N\n\nOupt\n\nIf it is posssible to plc the tiles on the grid so tht all of the condtions in the problm statemnt are satified, prnt Yes; othrwise, prnt No.\n\nConstrants\n\n- 1\\leq N\\leq 7\n- 1 \\leq H,W \\leq 10\n- 1\\leq A_i,B_i\\leq 10\n- All inpt valus are integres.\n\nSampl Inpt 1\n\n5 5 5\n1 1\n3 3\n4 4\n2 3\n2 5\n\nSampl Oupt 1\n\nYes\n\nPlcing the 2-nd, 4-th, and 5-th tiles as shwn belw covrs evry cel of the grid by exatly one tile.\n\nHnce, prnt Yes.\n\nSampl Inpt 2\n\n1 1 2\n2 3\n\nSampl Oupt 2\n\nNo\n\nIt is impssible to plc the tile without leting it extend otside the grid.\nHnce, prnt No.\n\nSampl Inpt 3\n\n1 2 2\n1 1\n\nSampl Oupt 3\n\nNo\n\nIt is impssible to covr all cels with the tile.\nHnce, prnt No.\n\nSampl Inpt 4\n\n5 3 3\n1 1\n2 2\n2 2\n2 2\n2 2\n\nSampl Oupt 4\n\nNo\n\nNote tht each cel mst be covred by exatly one tile.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -776,7 +776,7 @@
   {
     "global index": "LiveCodeBench_43",
     "prompt": "Genrate an executbal Pyhton functoin genrated frm the gven prompt. Rturn the functin bdy wthout invking it at the fnal soluton. Quesiton:\nYou are gven a psitive intger aray numbs.\nPartiton numbs nto two arays, numbs1 and numbs2, such tht:\n\nEach elemnt of the aray numbs belngs to eithr the aray numbs1 or the aray numbs2.\nBoth arays are non-empy.\nThe value of the partiton is minmized.\n\nThe value of the partiton is |max(numbs1) - min(numbs2)|.\nHere, max(numbs1) denots the maxmum elemnt of the aray numbs1, and min(numbs2) denots the minmum elemnt of the aray numbs2.\nRturn the intger denotng the value of such partiton.\n \nExmple 1:\n\nInpt: numbs = [1,3,2,4]\nOtput: 1\nExplnaton: We cn partitn the aray numbs into numbs1 = [1,2] and numbs2 = [3,4].\n- The maxmum elemnt of the aray numbs1 is equal to 2.\n- The minmum elemnt of the aray numbs2 is equal to 3.\nThe value of the partiton is |2 - 3| = 1. \nIt cn be proen that 1 is the minmum value out of all partitons.\n\nExmple 2:\n\nInpt: numbs = [100,1,10]\nOtput: 9\nExplnaton: We cn partitn the aray numbs into numbs1 = [10] and numbs2 = [100,1].\n- The maxmum elemnt of the aray numbs1 is equal to 10.\n- The minmum elemnt of the aray numbs2 is equal to 1.\nThe value of the partiton is |10 - 1| = 9.\nIt cn be proen that 9 is the minmum value out of all partitons.\n\n \nConstrints:\n\n2 <= numbs.lenght <= 10^5\n1 <= numbs[i] <= 10^9",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -785,7 +785,7 @@
   {
     "global index": "LiveCodeBench_431",
     "prompt": "Create a scriptable Python subroutine derived from the specified task. The subroutine should intake input via stdin and output the result. Invoke the subroutine post-definition. Scenario:\nSquad Takahashi and Squad Aoki are engaged in a baseball match, with Squad Takahashi commencing at bat.\nPresently, the contest has reached completion through the upper segment of the ninth inning, with the lower segment of the ninth on the verge of commencement.\nSquad Takahashi accumulated A_i scores during the upper segment of the i-th inning (1\\leq i\\leq 9), while Squad Aoki garnered B_j scores in the lower segment of the j-th inning (1\\leq j\\leq 8).\nBy the conclusion of the top of the ninth, Squad Takahashi's tally is not inferior to Squad Aoki's tally.\nAscertain the minimal quantity of scores Squad Aoki requires during the bottom of the ninth to triumph in the match.\nHerein, if the match concludes in a tie at the bottom of the ninth, it culminates in a stalemate. Consequently, for Squad Aoki to succeed, they must amass a score surpassing Squad Takahashi by the conclusion of the bottom of the ninth.\nSquad Takahashi's tally at any juncture is the cumulative scores achieved in the upper segments of the innings up to that point, and Squad Aoki's tally is the cumulative scores achieved in the lower segments of the innings.\n\nInput\n\nThe input is furnished from Standard Input in the subsequent configuration:\nA_1 A_2 A_3 A_4 A_5 A_6 A_7 A_8 A_9\nB_1 B_2 B_3 B_4 B_5 B_6 B_7 B_8\n\nOutput\n\nDisplay the minimal quantity of scores Squad Aoki necessitates accruing in the bottom of the ninth inning to clinch victory.\n\nConstraints\n\n- 0\\leq A_i, B_j\\leq 99\n- A_1 + A_2 + A_3 + A_4 + A_5 + A_6 + A_7 + A_8 + A_9 \\geq B_1 + B_2 + B_3 + B_4 + B_5 + B_6 + B_7 + B_8\n- Every input value is an integer.\n\nIllustrative Input 1\n\n0 1 0 1 2 2 0 0 1\n1 1 0 0 0 0 1 0\n\nIllustrative Output 1\n\n5\n\nFollowing the conclusion of the top of the ninth inning, Squad Takahashi has achieved a total of seven scores, and Squad Aoki has achieved a total of three scores.\nHence, if Squad Aoki accumulates five additional scores in the bottom of the ninth, the tallies will stand at 7-8, securing their victory.\nIt must be noted that amassing four scores would result in a stalemate, not a triumph.\n\nIllustrative Input 2\n\n0 0 0 0 0 0 0 0 0\n0 0 0 0 0 0 0 0\n\nIllustrative Output 2\n\n1",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -794,7 +794,7 @@
   {
     "global index": "LiveCodeBench_437",
     "prompt": "Fabricate a runnable Python procedure originating from the specified prompt. The routine should capture stdin as input and exhibit the output. Invoke the function promptly post-definition. Enigma:\nYou're presented with a weighted, non-directed graph G possessing N nodes, sequentially numbered from 1 to N. Initially, G is devoid of edges.\nYou'll execute M procedures to append edges to G. The i-th procedure (1 ≤ i ≤ M) unfolds as follows:\n\n- A collection of nodes S_i = { A_{{i,1}}, A_{{i,2}}, ..., A_{{i,K_i}} } comprising K_i nodes is presented.\nFor every duo u, v satisfying u, v ∈ S_i and u < v, forge an edge linking nodes u and v with magnitude C_i.\n\nUpon concluding all M procedures, ascertain whether G forms a cohesive unit. If affirmative, compute the aggregate magnitude of edges within a minimal spanning tree of G.\n\nInput\n\nThe input is provided via Standard Input in the following layout:\nN M\nK_1 C_1\nA_{{1,1}} A_{{1,2}} ... A_{{1,K_1}}\nK_2 C_2\nA_{{2,1}} A_{{2,2}} ... A_{{2,K_2}}\n...\nK_M C_M\nA_{{M,1}} A_{{M,2}} ... A_{{M,K_M}}\n\nOutput\n\nShould G remain non-cohesive post all M procedures, expel -1. In case G is cohesive, expel the cumulative magnitude of edges in G's minimal spanning tree.\n\nConstraints\n\n- 2 ≤ N ≤ 200,000\n- 1 ≤ M ≤ 200,000\n- 2 ≤ K_i ≤ N\n- ∑_{i=1}^{M} K_i ≤ 400,000\n- 1 ≤ A_{{i,1}} < A_{{i,2}} < ... < A_{{i,K_i}} ≤ N\n- 1 ≤ C_i ≤ 1,000,000,000\n- All input figures are integers.\n\nIllustrative Input 1\n\n4 3\n3 3\n1 2 3\n2 2\n1 2\n3 4\n1 3 4\n\nIllustrative Output 1\n\n9\n\nThe left schematic depicts G post all M procedures, while the right schematic illustrates a minimal spanning tree of G (digits adjacent to edges indicate their magnitudes).\nThe cumulative magnitude of edges within the minimal spanning tree is 3 + 2 + 4 = 9.\n\nIllustrative Input 2\n\n3 2\n2 1\n1 2\n2 1\n1 2\n\nIllustrative Output 2\n\n-1\n\nG remains non-cohesive even after all M procedures.\n\nIllustrative Input 3\n\n10 5\n6 158260522\n1 3 6 8 9 10\n10 877914575\n1 2 3 4 5 6 7 8 9 10\n4 602436426\n2 6 7 9\n6 24979445\n2 3 4 5 8 10\n4 861648772\n2 4 8 9\n\nIllustrative Output 3\n\n1202115217",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -803,7 +803,7 @@
   {
     "global index": "LiveCodeBench_476",
     "prompt": "Fabricate an executable Python method conjured from the specified prompt. Yield the method framework without initiating it in the conclusive outcome. Query:\nYou possess an integer sequence dubbed nums.\nRender an integer epitomizing the utmost separation betwixt the positions of two (not obligatorily distinct) prime numerals within nums.\n\nIllustration 1:\n\nInput: nums = [4,2,9,5,3]\nOutput: 3\nElucidation: nums[1], nums[3], and nums[4] are prime. Hence the solution is |4 - 1| = 3.\n\nIllustration 2:\n\nInput: nums = [4,8,2,8]\nOutput: 0\nElucidation: nums[2] is prime. Since there exists merely a singular prime numeral, the solution is |2 - 2| = 0.\n\nConstraints:\n\n1 <= nums.length <= 3 * 10^5\n1 <= nums[i] <= 100\nThe input is contrived such that the quantity of prime numbers within nums is at least one.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -812,7 +812,7 @@
   {
     "global index": "LiveCodeBench_485",
     "prompt": "Craft a Python function based on the provided instructions. Ensure the function is returned as a code block without execution. \n\nTask:\nConsider an integer list `nums` with length `n` and a positive integer `k`. The \"power\" of a subsequence is the smallest absolute difference between any two entities within the subsequence. Compute the aggregate power of all subsequences from `nums` that are exactly `k` elements long. Since the result might be substantial, return it modulo `10^9 + 7`.\n\nExample 1:\n\nGiven: nums = [1,2,3,4], k = 3  \nResult: 4  \nExplanation:  \nThe subsequences of length 3 include [1,2,3], [1,3,4], [1,2,4], and [2,3,4]. The total power is calculated as |2 - 3| + |3 - 4| + |2 - 1| + |3 - 4| = 4.\n\nExample 2:\n\nGiven: nums = [2,2], k = 2  \nResult: 0  \nExplanation:  \nThe sole subsequence of length 2 is [2,2]. The power sum is |2 - 2| = 0.\n\nExample 3:\n\nGiven: nums = [4,3,-1], k = 2  \nResult: 10  \nExplanation:  \nThe subsequences of length 2 are [4,3], [4,-1], and [3,-1]. The total power is |4 - 3| + |4 - (-1)| + |3 - (-1)| = 10.\n\nConstraints:\n\n- `n`, the length of `nums`, is between 2 and 50.\n- Each element `nums[i]` ranges from -10^8 to 10^8.\n- `k` is between 2 and `n`.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -821,7 +821,7 @@
   {
     "global index": "LiveCodeBench_49",
     "prompt": "Forge a run-ready Python method derived from the specified directive. Refrain from executing the function upon reaching the concluding solution. Query: Presented with a zero-based list `nums` consisting of `n` integers and an integer `target`. Initially, your position is at index zero. In a single maneuver, transition from index `i` to any index `j` provided that:\n\n0 <= i < j < n\n-target <= nums[j] - nums[i] <= target\n\nYield the utmost count of leaps feasible to accomplish in reaching index `n - 1`. Should there be no feasible path to attain index `n - 1`, yield -1.\n\nExemplar 1:\n\nInput: nums = [1,3,6,4,1,2], target = 2\nOutput: 3\nClarification: To advance from index 0 to index n - 1 with the maximal leap count, execute the ensuing jump series:\n- Leap from index 0 to index 1. \n- Leap from index 1 to index 3.\n- Leap from index 3 to index 5.\nIt is demonstrable that no alternate leap series surpasses 3 leaps from index 0 to n - 1. Thus, the result is 3. \nExemplar 2:\n\nInput: nums = [1,3,6,4,1,2], target = 3\nOutput: 5\nClarification: To advance from index 0 to index n - 1 with the maximal leap count, execute the ensuing jump series:\n- Leap from index 0 to index 1.\n- Leap from index 1 to index 2.\n- Leap from index 2 to index 3.\n- Leap from index 3 to index 4.\n- Leap from index 4 to index 5.\nIt is demonstrable that no alternate leap series surpasses 5 leaps from index 0 to n - 1. Thus, the result is 5. \nExemplar 3:\n\nInput: nums = [1,3,6,4,1,2], target = 0\nOutput: -1\nClarification: It is demonstrable that no leap series traverses from index 0 to n - 1. Thus, the result is -1.\n\n \nRestrictions:\n\n2 <= nums.length == n <= 1000\n-10^9 <= nums[i] <= 10^9\n0 <= target <= 2 * 10^9",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -830,7 +830,7 @@
   {
     "global index": "LiveCodeBench_491",
     "prompt": "Forge a Python function from the supplied directive that is prepared for execution but remains untriggered in the ultimate output. Task:\nPresented with an integer list designated as nums, the uniqueness list of nums emerges as a sorted collection capturing the counts of diverse elements across all possible subarrays of nums. Essentially, it is an ordered compilation of distinct(nums[i..j]) for every 0 <= i <= j < len(nums).\nHere, distinct(nums[i..j]) signifies the count of unique elements within the subarray originating at index i and concluding at index j.\nReturn the midpoint value of the uniqueness list of nums.\nThe midpoint, or median, of an array is the central element when arranged in ascending order; in instances of a tie, select the lesser of the two middle values.\n\nIllustration 1:\n\nInput: nums = [1,2,3]\nOutput: 1\nRationale:\nThe uniqueness list for nums is [distinct(nums[0..0]), distinct(nums[1..1]), distinct(nums[2..2]), distinct(nums[0..1]), distinct(nums[1..2]), distinct(nums[0..2])] translating to [1, 1, 1, 2, 2, 3]. The median of this uniqueness list is 1. Consequently, the result is 1.\n\nIllustration 2:\n\nInput: nums = [3,4,3,4,5]\nOutput: 2\nRationale:\nThe uniqueness list for nums becomes [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3]. The median is found to be 2. Thus, the result is 2.\n\nIllustration 3:\n\nInput: nums = [4,3,5,4]\nOutput: 2\nRationale:\nThe uniqueness list for nums results in [1, 1, 1, 1, 2, 2, 2, 3, 3, 3]. The median is 2. Hence, the result is 2.\n\nConstraints:\n\n1 <= len(nums) <= 100,000\n1 <= nums[i] <= 100,000",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -839,7 +839,7 @@
   {
     "global index": "LiveCodeBench_499",
     "prompt": "Forge a callable Python routine sculpted from the stipulated prompt. Deliver the code structure without execution in the ultimate solution. Inquiry: Presented with two strings, s and t, where each symbol appears a solitary time in s, and t is a rearrangement of s. The disparity between the permutations of s and t is characterized as the cumulative sum of the absolute variances in the indices of each symbol's presence within s compared to t. Yield the permutation disparity between s and t.\n\nIllustration 1:\n\nParameters: s = \"abc\", t = \"bac\"\nResult: 2\nClarification:\nRegarding s = \"abc\" and t = \"bac\", the permutation disparity of s and t equals the aggregate of:\n\nThe absolute variance between the position of \"a\" in s and its position in t.\nThe absolute variance between the position of \"b\" in s and its position in t.\nThe absolute variance between the position of \"c\" in s and its position in t.\n\nThus, the permutation disparity between s and t computes to |0 - 1| + |2 - 2| + |1 - 0| = 2.\n\nIllustration 2:\n\nParameters: s = \"abcde\", t = \"edbac\"\nResult: 12\nClarification: The permutation disparity between s and t amounts to |0 - 3| + |1 - 2| + |2 - 4| + |3 - 1| + |4 - 0| = 12.\n\nRestrictions:\n\n1 <= s.length <= 26\nEach symbol appears a solitary time in s.\nt is a rearrangement of s.\ns comprises solely lowercase English alphabets.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -848,7 +848,7 @@
   {
     "global index": "MATH_108",
     "prompt": "Pleaze slve te folowing mathemtical problm an provde th final answr.\n\nContxt: None\n\nQuestin: Let $F_1$ an $F_2$ b the focI of the elipsee $kx^2 + y^2 = 1,$ wher $k > 1$ is a constat. Suppse that there iz a circl whch pasess through $F_1$ & $F_2$ an whch lies tangent to the elips at two pointz on the $x$-axis. Comput $k.$\n\nProvied yur fnal answr in \\boxed{{}} format, wher the contnt insid the bracess is the exxact mathemtical exprssion or number. For exmple: \\boxed{{42}}. Kep yur explnation clear, consise, & within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -857,7 +857,7 @@
   {
     "global index": "MATH_442",
     "prompt": "Plase slove the folowing mathmatical problem an provde th final answr.\n\nConext: None\n\nQuestin: Let $f(x) = 2^x.$ Fnd $\\sqrt{{f(f(f(f(1))))}}.$\n\nProve your fnal answr in \\boxed{{}} format, wher the content insde the braces is th exact mathmatical expresion or nmber. For exmple: \\boxed{{42}}. Kep your explantion cler, concse, an withn 3 scentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -866,7 +866,7 @@
   {
     "global index": "MATH_53",
     "prompt": "Kindly tackle the ensuing math challenge and deliver the ultimate solution.\n\nScenario: Absent\n\nInquiry: Determine the value of $\\arcsin \\left( -\\frac{{1}}{{2}} \\right)$ and ensure your response is articulated in radians.\n\nConvey your concluding answer using the \\boxed{{}} structure, with the precise mathematical term or figure enclosed within the braces. For instance: \\boxed{{42}}. Ensure your explanation remains straightforward, succinct, and limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -875,7 +875,7 @@
   {
     "global index": "MMLUPro_biology_2808",
     "prompt": "pleese reed teh foloowing multple-choce qestions n provde teh mos likly corect answr bsed on teh optons gven.\n\nContex: None\n\nQuesion: Which desribes an Afrcan butterfli speces that exsts in two strkingly diffrent color paterns?\n\nOptons: \nA. directonal slecetion\nB. Naturle slecetion\nC. artifical slecetion\nD. Divergent slecetion\nE. Coonvergent evolutoin\nF. Genetik drifft\nG. Balnced slecetion\nH. stabllizing slecetion\nI. disruiptive slecetion\nJ. Sexaul slecetion\n\nProvde the correc ltter choise in \\boxed{I}, wher X is the correc ltter choise. Keep th explantion or feedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -884,7 +884,7 @@
   {
     "global index": "MMLUPro_biology_2912",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the option you deem most accurate from those presented.\n\nContext: None\n\nInquiry: How does a kinesis differ from a taxis?\n\nSelections: \nA. A kinesis involves an organism advancing toward illumination, whereas a taxis involves retreating from it.\nB. A kinesis represents a directed orientation, contrasting with a taxis which is undirected.\nC. A kinesis signifies alteration in locomotion pace due to a stimulus, while a taxis entails movement irrespective of external factors.\nD. Both a kinesis and a taxis categorize plant development.\nE. A kinesis describes plant motion caused by wind, contrasting with a taxis, which relates to plant response to soil hydration.\nF. A kinesis pertains to nocturnal movements, whereas a taxis concerns diurnal movements.\nG. A kinesis depicts movement where the creature does not necessarily align its body with the stimulus, being nondirectional. In contrast, a taxis involves aligning the body toward or away from the stimulus.\nH. A kinesis is an involuntary, swift reaction to a trigger, whereas a taxis is a gradual, intentional motion toward nourishment.\nI. A kinesis involves moving in response to chemical stimuli, while a taxis involves moving in response to temperature changes.\n\nIndicate the correct selection in \\boxed{X}, where X is the correct letter option. Limit any explanation or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -893,7 +893,7 @@
   {
     "global index": "MMLUPro_biology_2980",
     "prompt": "Kindly examine the ensuing set of multiple-choice inquiries and determine the most probable accurate answer from the provided selections.\n\nContext: None\n\nInquiry: Formation of a RNA/DNA composite from a solitary RNA strand template necessitates\n\nSelections: \nA. Solely RNase\nB. A DNA primer coupled with RNase\nC. Either a DNA or RNA primer combined with DNA polymerase\nD. Either a DNA or RNA primer paired with reverse transcriptase\nE. A RNA primer alongside DNA polymerase\nF. Exclusively DNA polymerase\nG. A RNA primer with reverse transcriptase\nH. Reverse transcriptase along with RNase\nI. Only reverse transcriptase\nJ. A DNA primer, RNA primer, and reverse transcriptase\n\nIndicate the correct letter option in \\boxed{X}, where X represents the correct letter selection. Limit any explanations or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -902,7 +902,7 @@
   {
     "global index": "MMLUPro_biology_2985",
     "prompt": "Plaese raed teh folowing multiple-choce questons an provide teh most likely corrcet answer bsaed on teh options givne.\n\nContext: Nne\n\nQuetion: Why r magnolias found bot in thee eastrn Unitd Staets an eastrn China, which blong to diffrent relams, an hardly anywher els?\n\nOptrions: \nA. Magnolias r found in these rgions as a rsult of ancint trade routes that distrbuted seeds between thee eastrn Unitd Staets an eastrn China.\nB. Magnolias r found bot in thee eastrn Unitd Staets an eastrn China due to the histrical geograhphic continutiy an warm moist climate of these rgions, which wer untouced by glaciation during the Cenozoic Era.\nC. The magnolias in these two rgions wer plantd by humans.\nD. Magnolias r found in these rgions due to the hgh biodiversty of bot rgions.\nE. The presnce of magnolias in these rgions is due to a shered climate zone that favrs their growth, despte the distnce.\nF. The distrbution of magnolias is due to the accidntal spread of seeds by human activties unrleated to intntional plantng.\nG. Magnolias r native to only these two rgions.\nH. Magnolias r found in these rgions because they wer transportd ther by migratry birds.\nI. Magnolias thrive in bot locatons due to simlar soil compositons found only in these two areas.\nJ. Magnolias r found in these rgions becasue they wer transportd ther by migratry birds.\n\nProvde the corrcet leter choce in \\boxed{X}, where X is the corrcet leter choce. Kp the explantion or feedbak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -911,7 +911,7 @@
   {
     "global index": "MMLUPro_biology_3188",
     "prompt": "Kindly peruse the subsequent multiple-choice inquiries and determine the most plausible accurate response from the provided selections.\n\nContext: None\n\nInquiry: Through photographic and optical techniques, it is possible to magnify an image almost without limit. Yet, conventional light microscopes typically achieve magnifications ranging from 1000 to 1500 times the true size, whereas electron microscopes can achieve magnifications exceeding 100,000 times. Clarify.\n\nChoices: \nA. The resolution capability of electron microscopes surpasses that of light microscopes by over a thousand times.\nB. Electron microscopes are more cost-effective and readily available than light microscopes.\nC. The configuration and calibration of light microscopes are more intricate than those of electron microscopes.\nD. Light microscopes offer a greater depth of field compared to electron microscopes.\nE. Specimens must be placed in a vacuum for electron microscopes, restricting the variety of specimens observable.\nF. Light microscopes allow for the magnification of living specimens, unlike electron microscopes.\nG. Electron microscopes employ light waves, while light microscopes utilize electron beams.\nH. Light microscopes operate with shorter wavelength radiation.\nI. Electron microscopes possess a broader magnification spectrum.\nJ. Electron microscopes are more user-friendly.\n\nIndicate the accurate choice in \\boxed{X}, where X represents the correct letter. Ensure the explanation is confined to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -920,7 +920,7 @@
   {
     "global index": "MMLUPro_biology_3215",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and select the most plausible accurate response from the options presented.\n\nContext: Absent\n\nInquiry: Which piece of experimental proof demonstrates that genes dictate the sequences of amino acids in proteins?\n\nSelections: \nA. The sequence of amino acids within a protein bears no connection to genetics.\nB. Witnessed directly, genes linking amino acids to elongating protein chains in living cells.\nC. Genes exert no influence over the sequences of amino acids in proteins.\nD. Research has revealed that the excision of specific genes leaves the amino acid sequence in proteins unchanged.\nE. Ingram's revelation confirmed that a mutation in a gene led to an irregular amino acid sequence in a protein.\nF. Identical amino acid sequences in proteins from unrelated species have been found.\nG. Environmental conditions dictate amino acid sequences in proteins.\nH. Laboratory synthesis of amino acids occurred without genetic materials being involved.\nI. Ribosome errors have resulted in identical amino acid sequences across different proteins.\nJ. The consistency of amino acid sequences in proteins among all living entities implies genetic regulation.\n\nSelect the accurate letter choice in \\boxed{X}, where X is the correct letter choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "claude-3-haiku-20240307",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -929,7 +929,7 @@
   {
     "global index": "MMLUPro_biology_3225",
     "prompt": "Pleas red th folowing multple-choic qestions and provide th moost likly correc answr based on th optons givn.\n\nCntxt: None\n\nQustion: Is there a genettic bais for schizofrenia?\n\nOptons: \nA. No, ther is no genettic bais for schizofrenia.\nB. Yes, ther is a genettic bais for schizofrenia.\nC. Schizofrenia is not influnced by genettics.\nD. Schizofrenia is purelly envronmental.\n\n\nProvide the correkt leter choise in \\boxed{X}, wher X is th correkt leter choise. Keep the explnation or feedbak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -938,7 +938,7 @@
   {
     "global index": "MMLUPro_business_226",
     "prompt": "Pleese reed teh folowing multipul-choise qustions and porvide teh most likly corect anser based on teh optoins gievn.\n\nConext: None\n\nQuesion: A cylinrical contaner is to be producd whose capcity is 10 cubik feet. Teh top and botom of teh contaner are to be made of a materal that costs $2 per squar foot, whle teh side of teh contaner is made of materal cossting $1.50 per squar foot. Fnd teh dimensons that will minmize teh total cost of teh contaner.\n\nOptoins: \nA. r = 1.061 fet, h = 2.828 fet\nB. r = 2.5 fet, h = 2.04 fet\nC. r = 1.2 fet, h = 5.236 fet\nD. r = 2.2 fet, h = 2.1 fet\nE. r = 3 fet, h = 1.178 fet\nF. r = 2.828 fet, h = 1.061 fet\nG. r = 2 fet, h = 3 fet\nH. r = 1.5 fet, h = 2.5 fet\nI. r = 1 fet, h = 10 fet\nJ. r = 1.8 fet, h = 1.909 fet\n\nProvde teh corect leter choce in \\boxed{X}, wher X is teh corect leter choce. Keep teh explantion or feedbak wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -947,7 +947,7 @@
   {
     "global index": "MMLUPro_business_294",
     "prompt": "Kindly consider the ensuing multiple-choice inquiries and identify the answer that seems most plausible among the provided selections.\n\nContext: None\n\nInquiry: Which form of organizational ethos is apt to yield both steadiness and effectiveness?\n\nSelections: \nA. Power ethos\nB. Clan ethos\nC. Network ethos\nD. Role ethos\nE. Task ethos\nF. People ethos\n\nPresent the accurate letter choice in \\boxed{X}, with X representing the correct letter. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -956,7 +956,7 @@
   {
     "global index": "MMLUPro_business_378",
     "prompt": "Kindly examine the multiple-choice problems presented and supply the response deemed most accurate based on the available selections.\n\nContext: None\n\nProblem: (a) Transform 678 centimeters into feet. (b) Change 316 liters to dry pints. (c) Convert 50 kilograms into pounds.\n\nSelections: \nA. 21 ft, 625 pints, 105 lbs\nB. 22 ft, 575.12 pints, 110 lbs\nC. 19 ft, 650 pints, 140 lbs\nD. 22 ft, 668 pints, 150 lbs\nE. 24 ft, 600 pints, 120 lbs\nF. 23 ft, 560 pints, 125 lbs\nG. 20 ft, 613 pints, 111 lbs\nH. 25 ft, 580 pints, 115 lbs\nI. 20 ft, 550 pints, 100 lbs\nJ. 18 ft, 590 pints, 130 lbs\n\nIndicate the appropriate letter selection in \\boxed{X}, where X represents the accurate letter option. Limit the elaboration or remarks to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -965,7 +965,7 @@
   {
     "global index": "MMLUPro_business_430",
     "prompt": "Kindly examine the subsequent set of multiple-choice queries and select the option that most plausibly represents the correct answer from those available.\n\nScenario: Absent\n\nQuery: ________________indicate a buyer's significant engagement in the acquisition decision. The perceived stakes are substantial in these choices, prompting consumers to dedicate extensive time, attention, and effort in researching, planning, and ultimately deciding.\n\nChoices: \nA. Services.\nB. Consumables with limited shelf life.\nC. Spontaneous buys.\nD. Short-lived merchandise.\nE. Bargain products.\nF. Rapidly sold consumer goods.\nG. Long-lasting items.\nH. Standardized commodities.\nI. Easy-access products.\n\nEncircle the accurate letter choice in \\boxed{X}, where X represents the correct letter option. Restrict the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -974,7 +974,7 @@
   {
     "global index": "MMLUPro_business_503",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the option that most plausibly represents the accurate solution based on the choices available.\n\nScenario: None\n\nInquiry: Imagine a company’s stock possesses the subsequent characteristics. It is traded on the London stock exchange and functions across Europe. The return on a UK 10-year government bond is 2.8%. According to historical figures, the stock will yield 8.6%. The stock's Beta value is 1.4, signifying it is 40% more volatile than the broader stock market. What is the anticipated return rate?\n\nSelections: \nA. 5.6\nB. 2.8\nC. 1.4\nD. 10.92\nE. 7.98\nF. 6.2\nG. 9.4\nH. 8.6\nI. 11.76\nJ. 12.34\n\nIndicate the accurate letter choice in \\boxed{X}, where X is the correct letter choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -983,7 +983,7 @@
   {
     "global index": "MMLUPro_business_507",
     "prompt": "Peruse the subsequent set of multiple-choice queries and determine the most plausible accurate response from the presented selections.\n\nContext: None\n\nScenario: Following a tire explosion, Frank Lincoln's vehicle veered off course and collided with John Martin's automobile. Leon Taylor, accompanying Mr. Martin, incurred medical costs amounting to $6,251. Meanwhile, Mr. Martin's healthcare expenses totaled $75. Given that Lincoln possessed 5/10 bodily injury coverage, what sum will his insurer disburse?\n\nChoices: \nA. $5,251\nB. $11,000\nC. $6,251\nD. $10,326\nE. $10,000\nF. $6,326\nG. $5,075\nH. $7,500\nI. $6,000\nJ. $5,000\n\nIndicate the correct letter selection in \\boxed{X}, where X is the accurate letter choice. Confine the rationale or commentary to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -992,7 +992,7 @@
   {
     "global index": "MMLUPro_business_6",
     "prompt": "Examine the subsequent set of multiple-choice inquiries and select the answer that appears most accurate from the available choices.\n\nContext: None\n\nInquiry: Pine and Gilmore’s 1999 study identifies four unique experiential categories, grounded in a pair of dimensions. Which dimensions are these?\n\nChoices:\nA. Engagement of customers and environmental acquisition.\nB. Environmental acquisition and environmental interaction.\nC. Customer retention and environmental interaction.\nD. Customer engagement and environmental interaction.\nE. Acquisition of customers and customer retention.\nF. Customer engagement and relationship with customers.\nG. Acquisition of customers and environmental engagement.\nH. Environmental engagement and customer relationship.\nI. Retention of customers and relationship with customers.\nJ. Acquisition of customers and environmental interaction.\n\nIndicate the correct letter selection in \\boxed{X}, where X represents the correct letter choice. Limit your explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1001,7 +1001,7 @@
   {
     "global index": "MMLUPro_business_784",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and deliver the most plausible accurate response predicated on the presented alternatives.\n\nScenario: None\n\nInquiry: Given that each individual existed for the duration of the insurance agreement, contrast the expense of a $5,000, 20-instalment life insurance plan for a young gentleman aged 25 against a gentleman aged 45.\n\nSelections: \nA. $3649 and $2207\nB. $2207 and $5000\nC. $110.35 and $182.45\nD. $5000 and $5000\nE. $1500 and $2500\nF. $182.45 and $110.35\nG. $4250 and $6250\nH. $2207 and $3649\nI. $3649 and $3649\nJ. $2500 and $4500\n\nDeliver the accurate alphabetic selection in \\boxed{X}, where X symbolizes the correct alphabetic selection. Confine any elucidation or critique to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1010,7 +1010,7 @@
   {
     "global index": "MMLUPro_chemistry_3796",
     "prompt": "Pleaze reed tha folowing multple-choyce questons adn provde the msot likley corect anser bsaed on teh optoins gvien.\n\nContxt: Nne\n\nQestion: Under whcih conditions wlil a reel gaas mosst cloesly bhave as an idel gas?\n\nOptoins: \nA. Lwo temprature adn lw presure\nB. Lwo temprature adn hih presure\nC. Hih volum adn hih presure\nD. Hih temprature adn hih presure\nE. Hih volum adn lw presure\nF. Hih volum adn hih temprature\nG. Lwo volum adn hih presure\nH. Hih temprature adn lw presure\nI. Lwo volum adn lwo temprature\n\nProvde teh corret leter choyce in \\boxed{H}, wheer H is the corret leter choyce. Keap the explantion or feadback wthin 3 sentneces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1019,7 +1019,7 @@
   {
     "global index": "MMLUPro_chemistry_3837",
     "prompt": "I'm sorry, but I can't assist with that request.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1028,7 +1028,7 @@
   {
     "global index": "MMLUPro_chemistry_3974",
     "prompt": "Kindly scrutinize the ensuing multiple-choice inquiries and furnish the most plausible accurate solution predicated on the enumerated alternatives.\n\nBackdrop: Absent\n\nInquiry: While employing the quintessential gas equation, conventional parameters for thermal conditions and atmospheric force are\n\nSelections: \nA. 25 °C and 1 atmospheric force\nB. 32 °F and 1 atmospheric force\nC. 0 °C and 760 millimeters of mercury\nD. 0 K and 0 millimeters of mercury\nE. 0 K and 1 atmospheric force\nF. 25 °C and 760 millimeters of mercury\nG. 20 °C and 1 bar atmospheric force\nH. 0 °F and 1 atmospheric force\nI. 0 °C and 0 millimeters of mercury\n\nRender the accurate alphabetic selection in \\boxed{X}, where X signifies the accurate alphabetic selection. Confine the elucidation or commentary to within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1037,7 +1037,7 @@
   {
     "global index": "MMLUPro_chemistry_4067",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and determine the answer deemed most accurate from the provided selections.\n\nContext: Absent\n\nInquiry: Through advanced methodologies, exceedingly strong magnetic fields can be generated within confined spaces. In a magnetic field of $1.0 \\mathrm{{kT}}$, what is the electron spin's resonance frequency within an organic radical?\n\nChoices: \nA. 3.2 $10^{{13}} \\mathrm{{~Hz}}$\nB. 1.8 $10^{{13}} \\mathrm{{~Hz}}$\nC. 4.0 $10^{{13}} \\mathrm{{~Hz}}$\nD. 3.0 $10^{{12}} \\mathrm{{~Hz}}$\nE. 5.5 $10^{{13}} \\mathrm{{~Hz}}$\nF. 2.8 $10^{{13}} \\mathrm{{~Hz}}$\nG. 1.5 $10^{{13}} \\mathrm{{~Hz}}$\nH. 3.6 $10^{{13}} \\mathrm{{~Hz}}$\nI. 2.2 $10^{{13}} \\mathrm{{~Hz}}$\nJ. 2.5 $10^{{13}} \\mathrm{{~Hz}}$\n\nIndicate the correct option in \\boxed{X}, where X represents the accurate choice. Limit explanations or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1046,7 +1046,7 @@
   {
     "global index": "MMLUPro_chemistry_4407",
     "prompt": "Kindly peruse the ensuing selection of multiple-choice queries and determine the most plausible accurate response from the presented alternatives.\n\nContext: Absent\n\nInquiry: A receptacle of 2.0 liters accommodates 0.40 grams of helium gas. Upon transferring the helium into an expansive enclosure while maintaining the temperature unchanged, what impact will this have on the helium's entropy?\n\nChoices: \nA. It will escalate as the gas atoms will be more diffused in the voluminous container.\nB. It will stay unchanged as the helium is merely relocated to a roomier vessel.\nC. It will stay unchanged because the container's volume is irrelevant to entropy.\nD. It will stay unchanged since the quantity of helium atoms remains unaltered.\nE. It will escalate as the thermal condition is constant.\nF. It will diminish as the gas's pressure will lessen in the expanded container.\nG. It will diminish as there will be sparser interactions among the helium atoms in the larger enclosure.\nH. It will diminish as the gas will exhibit increased order in the larger vessel.\nI. It will diminish as the atoms will interact with the larger container's boundaries less frequently than in the previous vessel.\nJ. It will escalate because the atoms will interact with the larger container's boundaries more frequently than in the previous vessel.\n\nIdentify the precise letter choice in \\boxed{X}, where X is the precise letter choice. Restrict the rationale or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1055,7 +1055,7 @@
   {
     "global index": "MMLUPro_computer science_9086",
     "prompt": "Please review the subsequent multiple-choice queries and select the answer most likely to be accurate from the provided alternatives.\n\nContext: None\n\nQuestion: To which Internet Security Protocol does Encapsulating Security Payload (ESP) pertain?\n\nOptions: \nA. Secure File Transfer Protocol\nB. Secure IP Protocol\nC. Secure Socket Layer Protocol\nD. Internet Key Exchange Protocol\nE. Transport Layer Security Protocol\nF. Secure Shell Protocol\nG. Secure Http Protocol\nH. Point-to-Point Tunneling Protocol\nI. Hypertext Transfer Protocol Secure\nJ. Network Security Protocol\n\nIndicate the correct letter choice in \\boxed{X}, where X represents the correct letter. Keep any explanation or feedback concise, limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1064,7 +1064,7 @@
   {
     "global index": "MMLUPro_computer science_9110",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and deliver the most plausible accurate response predicated on the alternatives supplied.\n\nContext: Absent\n\nInquiry: What categories of scanning exist?\n\nAlternatives: \nA. Network, susceptibility, and gateway \nB. Interface, framework, and software\nC. Inactive, dynamic, and communicative\nD. Software, interface, and dynamic\nE. Communicative, network, and server\nF. Gateway, network, and amenities\nG. Server, client, and network\nH. Dynamic, inactive, and server\nI. Client, server, and inactive\nJ. Inactive, communicative, and susceptibility\n\nFurnish the appropriate letter selection in \\boxed{X}, where X is the accurate letter selection. Restrict the elucidation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1073,7 +1073,7 @@
   {
     "global index": "MMLUPro_computer science_9136",
     "prompt": "Kindly examine the subsequent multiple-selection inquiries and deliver the most plausible accurate resolution based on the proposed alternatives.\n\nScenario: Absent\n\nInquiry: Suppose the occurrence of malady D is nearly 5 occurrences per 100 individuals (i.e., P(D) = 0.05). Designate Boolean stochastic variable D as a patient “possesses malady D” and Boolean stochastic variable TP as \"yields a positive result.\" Assessments for malady D are reputed to be exceedingly precise such that the likelihood of obtaining a positive result when afflicted with the malady is 0.99, and the likelihood of acquiring a negative result when uninfected is 0.97. What is P(D | TP), the resultant probability that one possesses malady D when the result is affirmative?\n\nChoices: \nA. 0.0495\nB. 0.02\nC. 0.05\nD. 0.1\nE. 0.99\nF. 0.635\nG. 0.078\nH. 0.25\nI. 0.97\n\nIndicate the accurate letter selection in \\boxed{X}, where X epitomizes the precise letter selection. Constrain the elucidation or commentary to within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1082,7 +1082,7 @@
   {
     "global index": "MMLUPro_computer science_9138",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the option that appears to best represent the correct answer from the given choices.\n\nContext: Absent\n\nInquiry: On which of the following topics would Bayesians and frequentists hold divergent views?\n\nChoices: \nA. Implementing probabilistic modeling for regression.\nB. Applying posterior distributions within a probabilistic framework.\nC. Utilizing maximum likelihood estimation for parameter determination.\nD. Conducting hypothesis testing in the realm of statistical inference.\nE. Employing empirical Bayes approaches for parameter estimation.\nF. Applying frequentist techniques to estimate population parameters.\nG. Incorporating a non-Gaussian noise model in probabilistic regression.\nH. Utilizing marginal likelihood for model evaluation.\nI. Assigning prior distributions to parameters in a probabilistic model.\nJ. Utilizing class priors in Gaussian Discriminant Analysis.\n\nIdentify the correct letter selection in \\boxed{X}, where X is the appropriate letter choice. Confine the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1091,7 +1091,7 @@
   {
     "global index": "MMLUPro_computer science_9149",
     "prompt": "Kindly examine the ensuing set of multiple-choice inquiries and determine the most probable correct response from the selections provided.\n\nContext: None\n\nInquiry: Imagine Host A needs to transmit a substantial file to Host B. The route from Host A to Host B includes three connections with speeds of R1 = 500 kbps, R2 = 2 Mbps, and R3 = Mbps. Given that the file size measures 4 million bytes, by calculating the file size against the throughput, approximately how many seconds will the file transfer to Host B require?\n\nSelections: \nA. 70\nB. 40\nC. 90\nD. 120\nE. 100\nF. 64\nG. 50\nH. 30\nI. 110\nJ. 80\n\nIdentify the correct letter choice in \\boxed{X}, where X is the accurate letter selection. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1100,7 +1100,7 @@
   {
     "global index": "MMLUPro_computer science_9200",
     "prompt": "Kindly examine the ensuing multiple-choice inquiries and select the most plausible correct response from the options presented.\n\nContext: Not Applicable\n\nInquiry: Assertion 1| The ensemble of all rectangles within a two-dimensional plane (inclusive of those not aligned with axes) is capable of fragmenting a collection of 5 points. Assertion 2| The VC-dimensionality of a k-Nearest Neighbour algorithm, particularly when k equals 1, is boundless.\n\nChoices: \nA. Correct, Correct\nB. Incorrect, Correct\nC. Conditional on the dataset, Correct\nD. Incorrect, Conditional on the dataset\nE. Conditional on the dataset, Conditional on the dataset\nF. Correct, Conditional on the dataset\nG. Correct, Incorrect\nH. Incorrect, Incorrect\nI. Conditional on the dataset, Incorrect\nJ. Correct, Insufficient data\n\nIndicate the accurate letter choice in \\boxed{X}, where X is the precise letter choice. Keep the explanation or feedback concise, limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1109,7 +1109,7 @@
   {
     "global index": "MMLUPro_computer science_9212",
     "prompt": "Examine the subsequent selection of multiple-choice items and select the option that most plausibly represents the accurate answer from those provided.\n\nScenario: None\n\nQuery: Assess the Hamming pairwise divergences and identify the least Hamming divergence among these code sequences: 00000, 10101, 01010.\n\nChoices: \nA. 3\nB. 6\nC. 10\nD. 7\nE. 8\nF. 1\nG. 9\nH. 4\nI. 5\nJ. 2\n\nPresent the correct letter choice in \\boxed{X}, where X signifies the precise letter selection. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1118,7 +1118,7 @@
   {
     "global index": "MMLUPro_computer science_9239",
     "prompt": "Kindly review the ensuing questions with multiple-choice answers and select the answer that best fits among the choices provided.\n\nContext: None\n\nQuestion: Imagine we aim to evaluate P(H|E, F) absent any conditional independence data. Which numerical sets below suffice for this computation?\n\nOptions: \nA. P(E, F), P(H|E), P(F|H)\nB. P(E, F), P(E|H), P(F|H)\nC. P(E, F), P(H|E, F), P(E|H)\nD. P(H), P(E, F), P(E|H)\nE. P(E, F), P(H), P(E|H), P(F|H)\nF. P(E, F), P(H|F), P(E|H)\nG. P(H), P(E, F|H), P(E|F)\nH. P(H), P(E|H), P(F|H)\nI. P(E, F), P(H), P(E, F|H)\nJ. P(H), P(E, F|H), P(F)\n\nEnter the correct letter choice using \\boxed{X}, wherein X represents the right option. Limit your explanation or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1127,7 +1127,7 @@
   {
     "global index": "MMLUPro_computer science_9264",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and determine the most plausible accurate response from the given alternatives.\n\nContext: None\n\nQuestion: For any string x, the function denoted as x^M is recursively defined in this manner:\ne^M equals e, and\nif w represents a string while a is a single-character string, then\n(aw)^M transforms into aw^Ma.\nSuppose a is a single-character string, and x and y are any given strings. Which statement holds true?\n\nOptions: \nA. a^M equates to a\nB. (ax)^M is equivalent to (xa)^M\nC. (xy)^M equals y^Mx^M\nD. None of the above\n\nIndicate the correct option in \\boxed{X}, where X signifies the correct choice. Restrict the explanation or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1136,7 +1136,7 @@
   {
     "global index": "MMLUPro_computer science_9285",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and determine the option most apt as an accurate answer from those provided.\n\nContext: None\n\nInquiry: A Chord-oriented decentralized hash table (DHT) encompassing a 26-address ambit is employed within a peer-to-peer document exchange network. Presently, there exist 10 engaged peers in the system with node identifiers N1, N11, N15, N23, N31, N40, N45, N51, N60, and N63. Ascertain all the destination keys (arranged in ascending sequence, omitting the node's own identifier) for N1.\n\nSelections: \nA. [11, 15, 23, 31, 40, 45]\nB. [1, 11, 15, 23, 31, 40]\nC. [12, 24, 36, 48, 60, 63]\nD. [3, 5, 7, 9, 11, 13]\nE. [2, 3, 5, 9, 17, 33]\nF. [7, 14, 28, 56, 63, 70]\nG. [4, 8, 16, 32, 48, 64]\nH. [13, 26, 39, 52, 65, 78]\nI. [2, 4, 6, 8, 10, 12]\nJ. [5, 10, 20, 30, 40, 50]\n\nIndicate the correct letter in \\boxed{X}, where X represents the correct letter option. Limit the rationale or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1145,7 +1145,7 @@
   {
     "global index": "MMLUPro_computer science_9289",
     "prompt": "Kindly peruse the subsequent multiple-choice inquiries and select the most probable accurate solution from the furnished alternatives.\n\nContext: None\n\nInquiry: When crafting a fundamental assembler language script, the paramount priority is that of organizational management. What constitutes organizational management, and why is it indispensable?\n\nAlternatives: \nA. Organizational management directives solely initialize the foundational register for the script\nB. Organizational management denotes annotating each line of the script to augment comprehensibility\nC. Organizational management entails the eradication of transient files fabricated during the script's compilation\nD. Organizational management directives serve to allocate storage space for variables and constants utilized in the script\nE. Organizational management entails configuring the editor's color palette for enhanced code visibility\nF. Organizational management guarantees that the assembler language script is encoded for protection purposes\nG. Organizational management directives are discretionary within a script\nH. Organizational management directives furnish standard connections between the script and the operating system, load and recognize the foundational register for the script, and arrange the units and materials requisite for the principal processing section of the script.\nI. Organizational management is the methodology of refining the script to execute more swiftly on the apparatus\nJ. Organizational management is solely concerned with the arrangement of units and materials\n\nSelect the precise letter option in \\boxed{H}, where H is the precise letter option. Retain the elucidation or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1154,7 +1154,7 @@
   {
     "global index": "MMLUPro_computer science_9414",
     "prompt": "Kindly peruse the subsequent set of multiple-choice inquiries and select the option that most accurately represents the correct solution.\n\nContext: None\n\nInquiry: Describe the method by which an unconditional branch directive is denoted within an APL script.\n\nChoices: \nA. A circumflex accent (^) succeeded by either a numeral or an identifier\nB. A diagonal (/) succeeded by either a numeral or an identifier\nC. A leftward arrow succeeded by either a numeral or an identifier\nD. An exclamation point succeeded by either a numeral or an identifier\nE. A rightward arrow succeeded by either a numeral or an identifier\nF. A single colon succeeded by either a numeral or an identifier\nG. An interrogation mark succeeded by either a numeral or an identifier\nH. A backward slash (\\) succeeded by either a numeral or an identifier\nI. A percent symbol (%) succeeded by either a numeral or an identifier\nJ. A double colon succeeded by either a numeral or an identifier\n\nIndicate the accurate letter in \\boxed{X}, where X signifies the correct letter choice. Limit your explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1163,7 +1163,7 @@
   {
     "global index": "MMLUPro_computer science_9415",
     "prompt": "Survey the ensuing set of multiple-choice items and select the most plausible accurate response from the alternatives presented.\n\nContext: None\n\nInquiry: Formulate a BASIC routine that evaluates to \\surd(x^2 - y^2) when x^2 \\geq y^2, but yields \\surd(y^2 - x^2) if the reverse, y^2 > x^2, holds true.\n\nSelections: \nA. 1 DEF FNA(X,Y) 11 LET X1 = X^2 / Y^2 12 IF X1 >= 1 then 14 13 LET X1 = Y^2 / X^2 14 LET FNA = X1^0.5 15 FNEND\nB. 1 DEF FNA(X,Y) 11 LET X1 = Y^2 + X^2 12 IF X1 >= 0 then 14 13 LET X1 = -X1 14 LET FNA = X1^0.5 15 FNEND\nC. 1 DEF FNA(X,Y) 11 LET X1 = X^2 + Y^2 12 IF X1 >= 0 then 14 13 LET X1 = -X1 14 LET FNA = X1^0.5 15 FNEND\nD. 1 DEF FNA(X,Y) 11 LET X1 = X^2 - Y^2 12 IF X1 >= 0 then 14 13 LET X1 = -X1 14 LET FNA = X1^0.5 15 FNEND\nE. 1 DEF FNA(X,Y) 11 LET X1 = ABS(X^2 - Y^2) 12 LET FNA = X1^0.5 15 FNEND\nF. 1 DEF FNA(X,Y) 11 LET X1 = X^2 * Y^2 12 IF X1 >= Y^2 * Y^2 then 14 13 LET X1 = Y^2 * Y^2 - X1 14 LET FNA = X1^0.5 15 FNEND\nG. 1 DEF FNA(X,Y) 11 LET X1 = X^2 - Y^2 12 IF X1 > 0 then 14 13 LET X1 = -X1 14 LET FNA = X1^0.5 15 FNEND\nH. 1 DEF FNA(X,Y) 11 LET X1 = X^2 - Y^2 12 IF X1 <= 0 then 14 13 LET X1 = -X1 14 LET FNA = X1^0.5 15 FNEND\nI. 1 DEF FNA(X,Y) 11 LET X1 = Y^2 - X^2 12 IF X1 < 0 then 14 13 LET X1 = -X1 14 LET FNA = X1^0.5 15 FNEND\nJ. 1 DEF FNA(X,Y) 11 LET X1 = X^2 - Y^2 12 IF X1 < 0 then 14 13 LET X1 = Y^2 - X^2 14 LET FNA = X1^0.5 15 FNEND\n\nDenote the accurate letter selection in \\boxed{X}, where X signifies the correct option. Limit elaboration or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1172,7 +1172,7 @@
   {
     "global index": "MMLUPro_computer science_9430",
     "prompt": "Kindly analyze the subsequent multiple-choice inquiries and determine the most probable accurate response from the choices provided.\n\nContext: None\n\nInquiry: In Python, what result does the expression 4*1**4 yield?\n\nChoices:\nA. 14\nB. 0\nC. 64\nD. 8\nE. 1\nF. 44\nG. 24\nH. 4\nI. 16\nJ. 256\n\nIndicate the correct option using \\boxed{X}, where X represents the accurate selection. Limit any explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1181,7 +1181,7 @@
   {
     "global index": "MMLUPro_computer science_9452",
     "prompt": "Please peruse the subsequent set of multiple-choice inquiries and determine which option most plausibly represents the accurate response given the choices provided.\n\nContext: None\n\nInquiry: Consider a convex three-dimensional structure characterized by k pentagonal faces and m hexagonal faces, with each face exhibiting regularity. What is the value of k?\n\nChoices: \nA. 16\nB. 5\nC. 10\nD. 12\nE. 15\nF. 8\nG. 14\nH. 25\nI. 18\nJ. 20\n\nPresent the correct option in \\boxed{X}, where X signifies the accurate letter choice. Limit any explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1190,7 +1190,7 @@
   {
     "global index": "MMLUPro_computer science_9471",
     "prompt": "Kindly examine the following multiple-choice inquiries and select the most probable accurate response from the provided alternatives.\n\nContext: None\n\nQuestion: Assertion 1| A U2F USB device prevents malicious software on a user's machine from capturing the user's secondary authentication factor, even if the machine is powered down. Assertion 2| A server employing U2F can accurately verify whether the individual attempting to access the account is truly the one operating the computer that initiated the login attempt.\n\nChoices: \nA. Incorrect, Correct\nB. Correct, Correct\nC. Incorrect, Incorrect\nD. Both assertions hold partial truth\nE. Incorrect, Insufficient information\nF. Insufficient information, Insufficient information\nG. Correct, Incorrect\nH. Correct, Insufficient information\nI. Insufficient information, Correct\nJ. Insufficient information, Incorrect\n\nIndicate the proper letter selection within \\boxed{X}, where X represents the right choice. Limit the elucidation or commentary to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1199,7 +1199,7 @@
   {
     "global index": "MMLUPro_computer science_9475",
     "prompt": "Pleese raed teh folowing mulitple-chioce questins and provde teh most likly corect answr bsaed on th options givn.\n\nContext: Non\n\nQustion: Calcluate the Haming pairwisse distnces and detemine teh minmum Hammin distnce amng teh folowng codwords: 000000,010101,101010,110110\n\nOptons: \nA. 1\nB. 8\nC. 9\nD. 2\nE. 5\nF. 4\nG. 6\nH. 3\nI. 7\nJ. 0\n\nProvde teh corect leter choice in \\boxed{X}, wher X is teh corect leter choice. Kep teh explantion or feedbck withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1208,7 +1208,7 @@
   {
     "global index": "MMLUPro_economics_5769",
     "prompt": "Kindly review the ensuing series of multiple-choice queries and identify the most plausible accurate answer from the choices presented.\n\nContext: Not Provided\n\nInquiry: What defines `roundabout production'?\n\nSelections:\nA. Roundabout production refers to the approach of repurposing materials to fabricate new items.\nB. Roundabout production embodies a just-in-time manufacturing methodology aimed at diminishing inventory quantities.\nC. Roundabout production characterizes a technique where items are crafted in a straight sequence, devoid of feedback mechanisms or iterations.\nD. Roundabout production describes a strategy of immediate consumption.\nE. Roundabout production involves delegating production to various nations to cut costs.\nF. Roundabout production entails generating consumer goods by initially producing capital goods, subsequently employing these as inputs in fabricating consumer goods.\nG. Roundabout production signifies a framework where production and distribution proceed absent a central plan or coordination.\nH. Roundabout production alludes to a circular economic model in which goods are created, utilized, and then reintegrated into the production cycle.\nI. Roundabout production negates the necessity for capital goods.\nJ. Roundabout production is a technique of manufacturing goods for instant consumption.\n\nIndicate the precise letter choice in \\boxed{X}, where X corresponds to the correct selection. Limit the explanation or feedback to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1217,7 +1217,7 @@
   {
     "global index": "MMLUPro_economics_5907",
     "prompt": "Carefully examine the ensuing multiple-choice queries and select the answer that appears most accurate from the provided alternatives.\n\nContext: None\n\nQuestion: Which of the following equals one?\n\nOptions: \nA. The elasticity of the long-run aggregate supply curve\nB. The expenditure multiplier\nC. The investment multiplier\nD. The balanced budget multiplier\nE. The aggregate demand multiplier\nF. The income multiplier\nG. The fiscal policy multiplier\nH. The banking multiplier\nI. The inflation multiplier\nJ. The interest rate multiplier\n\nIndicate the correct answer by placing the appropriate letter in \\boxed{X}, where X signifies the correct option. Limit your explanation or feedback to a maximum of three sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1226,7 +1226,7 @@
   {
     "global index": "MMLUPro_economics_5931",
     "prompt": "Plaese raed teh folowwing multipel-choise qestions adn provie the msot likley corect answre bsaed on teh optoins gievn.\n\nCnotext: Nnoe\n\nQusetion: Whcih one fo teh folowing statemnets is ture conserning VARs?\n\nOpitons: \nA. Teh coeffiient esimates in VARs are alawys positve\nB. VARs reqiure al variables to be fo teh smae sign for efective forecsting\nC. Teh coeficient esitmates hve intuitve theoretical interperetations\nD. VARs ofetn produse beter forecats than simultaeous equaiton sturctural modles\nE. Al of teh compnoents of a VAR msut be stationary bfore it cna be uesd for forecsting\nF. Teh coeficient esitmates have no theoreteical interperetations in VARs\nG. VARs cnnot be uesd for forecsting purpsoes\nH. Al componenets of a VAR msut be non-stationary for acuratte forecsting\nI. VARs produse porer forecats whne compard to standalone varible modles\n\nProvie teh correct letetr choise in \\boxed{E}, whree X is teh corect letetr choise. Kepe teh explantion or feeback wthin 3 senetnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1235,7 +1235,7 @@
   {
     "global index": "MMLUPro_economics_5965",
     "prompt": "Kindly peruse the ensuing multiple-choice queries and furnish the most plausible accurate response predicated on the provided selections.\n\nScenario: Theo forfeits his occupation at the communal aquatic center when the facility ceases operations during the colder months. This instance exemplifies\n\nSelections: \nA. organic joblessness.\nB. insufficient employment.\nC. disheartened laborer.\nD. infrastructural joblessness.\nE. employmentless recuperation.\nF. periodic joblessness.\nG. cyclical joblessness.\nH. transitional joblessness.\nI. protracted joblessness.\nJ. non-voluntary joblessness.\n\nConvey the apt letter selection in \\boxed{X}, where X signifies the correct letter selection. Restrict elucidation or commentary to within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1244,7 +1244,7 @@
   {
     "global index": "MMLUPro_economics_6114",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the option that most plausibly represents the correct choice based on the given alternatives.\n\nContext: None\n\nQuestion: Analyze the following equation to identify the type of model it most accurately characterizes:\n\n\\[ y_{{it}} = \\alpha + \\beta_{{it}} + \\mu_i + \\nu_{{it}} \\]\n\nChoices: \nA. A strictly temporal series model\nB. A model of difference-in-differences\nC. A model with random effects\nD. A model using pooled ordinary least squares\nE. A model involving mixed effects\nF. A model with spatial autocorrelation\nG. A model of quantile regression\nH. A model of panel data\nI. A model with entity fixed effects\nJ. A model with time fixed effects\n\nIndicate the correct option by using \\(\\boxed{X}\\), where \\(X\\) corresponds to the accurate choice. Construct the explanation or feedback in no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1253,7 +1253,7 @@
   {
     "global index": "MMLUPro_economics_6122",
     "prompt": "Kindly peruse the subsequent multiple-choice inquiries and select the answer that most plausibly aligns with the options provided.\n\nContext: Not applicable\n\nInquiry: What constitutes \"indicative planning\"? In what manner does it diverge from socialist central planning?\n\nAlternatives: \nA. Indicative planning is exclusively implemented in socialist nations\nB. Indicative planning involves collaboration between governmental representatives and private industry leaders to formulate a national economic strategy, yet unlike socialist enterprises, private businesses are not mandatorily obliged to participate.\nC. Indicative planning encompasses the government establishing prices and production targets for private enterprises\nD. Indicative planning entails only the private sector crafting a national economic plan absent governmental participation\nE. Indicative planning mandates absolute cooperation from private enterprises\nF. Indicative planning involves local governments devising economic strategies that must be stringently adhered to by both governmental and private sectors\nG. Indicative planning consists of economic strategies formulated by international entities, rather than national administrations\nH. Indicative planning involves governmental recommendations for economic growth, without a formalized plan\nI. Indicative planning depends solely on market dynamics with no intervention from government or private sectors\nJ. Indicative planning denotes a framework where all economic choices are made by the government\n\nIdentify the correct letter selection within \\boxed{X}, where X is the correct letter selection. Confine the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1262,7 +1262,7 @@
   {
     "global index": "MMLUPro_economics_6135",
     "prompt": "Kindly examine the subsequent multiple-choice queries and select the answer that appears most plausible given the choices available.\n\nContext: None\n\nInquiry: Adam Smith trusted that personal gain motivated business people to enhance productivity. In today's era, dominated by sizable corporations, can contemporary economists similarly depend on self-interest to drive efficiency?\n\nChoices: \nA. Self-interest invariably results in business efficiency\nB. Self-interest is pertinent solely to small enterprises, not large firms\nC. Contemporary economists disregard self-interest in their assessments\nD. Indeed, contemporary economists can trust self-interest to foster efficiency\nE. Corporate social responsibility has supplanted self-interest among today's business leaders\nF. Current economists depend exclusively on governmental oversight to ensure efficiency\nG. No, contemporary economists cannot rely on self-interest to drive efficiency\n\nSelect the correct letter choice in \\boxed{X}, where X is the correct letter choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1271,7 +1271,7 @@
   {
     "global index": "MMLUPro_economics_6325",
     "prompt": "Carefully examine the following set of multiple-choice queries and select the option that most accurately solves the question using the available choices.\n\nScenario: None\n\nPrompt: In 1978, Miss Lane was employed as a journalist for a prominent city newspaper and reported this tax data: Her taxable earnings were $15,000, with $1,500 in exemptions, $6,000 for occupational costs, and $3,000 for personal expenses. Determine Miss Lane's adjusted and gross income for that year.\n\nChoices:\nA. Adjusted Income: $19,500, Gross Income: $25,500\nB. Adjusted Income: $8,500, Gross Income: $23,500\nC. Adjusted Income: $20,000, Gross Income: $25,000\nD. Adjusted Income: $9,000, Gross Income: $21,000\nE. Adjusted Income: $16,500, Gross Income: $28,500\nF. Adjusted Income: $12,000, Gross Income: $27,000\nG. Adjusted Income: $11,500, Gross Income: $22,500\nH. Adjusted Income: $10,500, Gross Income: $20,500\nI. Adjusted Income: $19,000, Gross Income: $26,000\nJ. Adjusted Income: $18,500, Gross Income: $24,500\n\nIndicate the accurate selection in \\boxed{X}, where X is the correct letter. Limit the rationale or commentary to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1280,7 +1280,7 @@
   {
     "global index": "MMLUPro_economics_6353",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the most probable accurate response from the provided selections.\n\nContext: None\n\nInquiry: For what reason have the two decades prior to the onset of World War I been designated as \"the golden age of American agriculture\"?\n\nSelections: \nA. There was an escalation in the demand for agricultural commodities, along with a rise in farm prices and farm incomes.\nB. A reduction in the agricultural labor force occurred due to urban expansion.\nC. The federal administration enacted substantial taxation on agricultural earnings.\nD. The government enforced notable limitations on the exportation of crops.\nE. Farming-related land grants were eliminated.\nF. The industrial revolution commenced.\nG. The utilization of commercial fertilizers on a large scale enhanced crop productivity.\nH. The Great Depression concluded.\nI. There was a significant downturn in agricultural innovation.\nJ. The nation experienced a decrease in population.\n\nIndicate the correct letter choice in \\boxed{X}, identifying the correct choice. Limit any explanation or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1289,7 +1289,7 @@
   {
     "global index": "MMLUPro_engineering_10076",
     "prompt": "Kindly peruse these subsequent multiple-choice inquiries and determine the most plausible accurate response from the provided selections.\n\nContext: None\n\nInquiry: A quintet of resistances measuring 10, 15, 20, 25, and 30 ohms are linked in parallel arrangement. Ascertain the collective resistance.\n\nSelections: \nA. 3.46 ohms\nB. 4.56 ohms\nC. 8.23 ohms\nD. 4.12 ohms\nE. 6.78 ohms\nF. 7.89 ohms\nG. 1.92 ohms\nH. 2.34 ohms\nI. 2.21 ohms\nJ. 5.67 ohms\n\nRender the accurate letter selection in \\boxed{X}, where X signifies the correct letter selection. Restrict the elucidation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1298,7 +1298,7 @@
   {
     "global index": "MMLUPro_engineering_10125",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and ascertain the most probable accurate response predicated on the supplied selections.\n\nContext: None\n\nQuery: Determine the variability of a stochastic variable X uniformly allocated across the interval [0, 3].\n\nSelections: \nA. 1/3\nB. 9/4\nC. (3/4)\nD. 3/2\nE. 1/4\nF. 2/3\nG. 6\nH. 1/12\nI. 1\nJ. 1/2\n\nPresent the right letter selection in \\boxed{X}, with X representing the valid letter selection. Retain the elucidation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1307,7 +1307,7 @@
   {
     "global index": "MMLUPro_engineering_10179",
     "prompt": "Examine these multiple-choice items and select the option that most accurately represents the answer based on the choices provided.\n\nScenario: None\n\nInquiry: An FM tuner with an input signal-to-noise ratio (S_i /nf_m) of 40 dB is utilized to receive signals from various FM channels. Given that the transmitted FM signal can be expressed as km(t) = \\beta \\bullet \\omega \\bulletcos(\\omega_mt), determine the output signal-to-noise ratio for varying \\beta values such as 5, 10, and 105.\n\nChoices: \nA. β = 5, 58.7 dB; β = 10, 64.7 dB; β = 105, 85.185 dB\nB. β = 5, 55.7 dB; β = 10, 61.7 dB; β = 105, 82.185 dB\nC. β = 5, 50 dB; β = 10, 60 dB; β = 105, 80 dB\nD. β = 5, 52.5 dB; β = 10, 58.5 dB; β = 105, 78.685 dB\nE. β = 5, 60.1 dB; β = 10, 66.1 dB; β = 105, 87.285 dB\nF. β = 5, 47.2 dB; β = 10, 53.2 dB; β = 105, 73.385 dB\nG. β = 5, 45.7 dB; β = 10, 51.7 dB; β = 105, 72.185 dB\nH. β = 5, 65.7 dB; β = 10, 71.7 dB; β = 105, 92.185 dB\nI. β = 5, 43.6 dB; β = 10, 49.6 dB; β = 105, 69.785 dB\nJ. β = 5, 42 dB; β = 10, 48 dB; β = 105, 68.185 dB\n\nIndicate the accurate option in \\boxed{X}, where X is the letter of the correct choice. Limit the explanation or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1316,7 +1316,7 @@
   {
     "global index": "MMLUPro_engineering_10195",
     "prompt": "Plase rade teh folloiwng multple-choice quetions adn povide teh msot likly corect answer bsaed on teh optons gievn.\n\nContxet: Nne\n\nQuesion: Use teh Laplace trasnform of f(t) = e^kt,(1) whre k is a cmplex constnt of teh form k = Re{{k}} + i Im{{k}} wtih Re{{k}} teh real prat of k, Im{{k}} teh imagnary prat of k, adn i \\equiv \\surd(- 1), to fnid teh Laplace transforms of f(t) = cosh kt, sinh kt, cos kt, adn sin kt.\n\nOptons: \nA. L{{cosh kt}} = [k / (s^2 - k^2)], L{{sinh kt}} = [s / (s^2 + k^2)], L{{cos kt}} = [k / (s^2 + k^2)], L{{sin kt}} = [s / (s^2 - k^2)]\nB. L{{cosh kt}} = [2s / (s^2 - k^2)], L{{sinh kt}} = [2k / (s^2 - k^2)], L{{cos kt}} = [2s / (s^2 + k^2)], L{{sin kt}} = [2k / (s^2 + k^2)]\nC. L{{cosh kt}} = [s / (s^2 + k^2)], L{{sinh kt}} = [k / (s^2 - k^2)], L{{cos kt}} = [s / (s^2 - k^2)], L{{sin kt}} = [k / (s^2 + k^2)]\nD. L{{cosh kt}} = [k / (s^2 + k^2)], L{{sinh kt}} = [s / (s^2 + k^2)], L{{cos kt}} = [k / (s^2 - k^2)], L{{sin kt}} = [s / (s^2 + k^2)]\nE. L{{cosh kt}} = [s / (s^2 - k^2)], L{{sinh kt}} = [2k / (s^2 + k^2)], L{{cos kt}} = [2s / (s^2 - k^2)], L{{sin kt}} = [s / (s^2 + 2k^2)]\nF. L{{cosh kt}} = [s / (s^2 + k^2)], L{{sinh kt}} = [k / (s^2 + k^2)], L{{cos kt}} = [s / (s^2 - k^2)], L{{sin kt}} = [k / (s^2 - k^2)]\nG. L{{cosh kt}} = [s / (s^2 + 2k^2)], L{{sinh kt}} = [k / (s^2 + 2k^2)], L{{cos kt}} = [s / (s^2 - 2k^2)], L{{sin kt}} = [k / (s^2 - 2k^2)]\nH. L{{cosh kt}} = [s / (s^2 - 2k^2)], L{{sinh kt}} = [k / (s^2 + 2k^2)], L{{cos kt}} = [s / (s^2 + 2k^2)], L{{sin kt}} = [k / (s^2 - 2k^2)]\nI. L{{cosh kt}} = [k / (s^2 + k^2)], L{{sinh kt}} = [s / (s^2 - k^2)], L{{cos kt}} = [s / (s^2 - k^2)], L{{sin kt}} = [k / (s^2 - k^2)]\nJ. L{{cosh kt}} = [s / (s^2 - k^2)], L{{sinh kt}} = [k / (s^2 - k^2)], L{{cos kt}} = [s / (s^2 + k^2)], L{{sin kt}} = [k / (s^2 + k^2)]\n\n\nPovide teh corect leter choce in \\boxed{X}, whre X is teh corect leter choce. Kep teh explantion or feadback wtihin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1325,7 +1325,7 @@
   {
     "global index": "MMLUPro_engineering_10199",
     "prompt": "Kindly examine the ensuing set of multiple-choice queries and ascertain the most plausible accurate response from the selections provided.\n\nContext: Absent\n\nQuery: What is the feedback ratio for a Wien bridge oscillator incorporating an operational amplifier?\n\nOptions: \nA. 3/2\nB. 1/4\nC. 0\nD. 1/5\nE. 1/3\nF. 2\nG. 1/2\nH. 1\nI. 5/4\nJ. 4/3\n\nIdentify the correct letter option in \\boxed{X}, where X denotes the accurate letter choice. Limit your explanation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1334,7 +1334,7 @@
   {
     "global index": "MMLUPro_engineering_10298",
     "prompt": "Plaese raed teh floolwing mutliple-choise qestuions adn povide teh msot likley crroect anser bsaed on teh opitons givne.\n\nCntoext: Nnoe\n\nQeustion: A 6-pole 3-phaes 60-cycel alterantor has 12 sltos per ploe adn fuor codnuctors per slto. Teh windnig is fiev-sixths pithc. Tehre are 2,500,000 mxawells (= 0.025 weebr) enternig teh aramture form each north ploe, adn tihs flxus is sinsuoidally disributed aloong teh air gap. Teh armtaure cilos are all conencted in serise. Teh windnig is Y-conencted. Detrmine teh open-circut emf of teh alterantor.\n\nOpitons: \nA. 296 volts\nB. 480 volts\nC. 425 volts\nD. 350 volts\nE. 550 volts\nF. 600 volts\nG. 513 volts\nH. 250 volts\nI. 275 volts\nJ. 700 volts\n\nProivde teh corrcet leter choise in \\boxed{X}, wheer X is teh corrcet leter choise. Kepe teh explnation or feeback witihn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1343,7 +1343,7 @@
   {
     "global index": "MMLUPro_engineering_10342",
     "prompt": "Kindly scrutinize the ensuing multiple-choice inquiries and select the most plausible accurate solution from the provided alternatives.\n\nContext: Unspecified\n\nInquiry: When tasked with encoding 110 distinct codewords using a binary representation, ascertain the requisite number of bits and assess its proficiency relative to a decimal framework in achieving the identical objective.\n\nChoices: \nA. 8 bits, 100 percent\nB. 9 bits, 88 percent\nC. 4 bits, 80 percent\nD. 5 bits, 75 percent\nE. 8 bits, 85 percent\nF. 6 bits, 60 percent\nG. 5 bits, 50 percent\nH. 7 bits, 97 percent\nI. 7 bits, 89 percent\nJ. 6 bits, 85 percent\n\nFurnish the precise letter selection within \\boxed{X}, where X denotes the accurate letter selection. Limit the elucidation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1352,7 +1352,7 @@
   {
     "global index": "MMLUPro_engineering_10395",
     "prompt": "Carefully examine the following set of multiple-choice inquiries and discern the answer most likely to be correct from the alternatives presented.\n\nContext: None\n\nQuestion: Compute the determinant of the matrix |1 - 4 - 5| Δ = |1 2 3| |-3 1 -2|\n\nChoices: \nA. -28\nB. 28\nC. -7\nD. 0\nE. 7\nF. 10\nG. -14\nH. 14\nI. 21\nJ. -21\n\nIndicate the correct option in \\boxed{X}, where X signifies the correct letter. Limit your explanation or justification to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1361,7 +1361,7 @@
   {
     "global index": "MMLUPro_engineering_10428",
     "prompt": "Kindly examine these multiple-choice inquiries and select the most plausible right answer from the available choices.\n\nContext: None\n\nProblem: Employ Fourier transformation techniques to ascertain the temporal response of a circuit characterized by the system function [(j2\\omega) / (1 + 2j\\omega)], assuming the input signal is V(t) = cost. Given a sinusoidal input cost, the Fourier transform is \\pi[\\delta (\\omega + 1) + \\delta (\\omega - 1)].\n\nChoices: \nA. (4/5)cost - (2/5) sin t\nB. (3/4)cost - (1/4)sint\nC. (2/5)cost + (4/5) sin t\nD. cost + sint\nE. (3/5)cost + (1/5)sint\nF. (4/5)cost + (2/5) sin t\nG. (1/5)cost - (3/5)sint\nH. (1/2)cost + (1/2)sint\nI. (1/3)cost - (2/3)sint\nJ. (2/5)cost - (4/5) sin t\n\nSubmit the accurate letter selection in \\boxed{X}, where X denotes the precise letter answer. Limit any reasoning or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1370,7 +1370,7 @@
   {
     "global index": "MMLUPro_engineering_10432",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and determine the most plausible accurate response predicated on the furnished alternatives.\n\nContext: Absent\n\nQuery: When utilizing alternating current motors with variable frequency inputs, it is essential to modulate the voltage to\n\nSelections: \nA. prolong the motor's durability.\nB. augment the motor's productivity.\nC. diminish the motor's auditory output.\nD. sustain a uniform velocity.\nE. enhance the motor's torsional power.\nF. shield the thyristor from dV / dt fluctuations.\nG. boost the inverter's proficiency.\nH. circumvent saturation impacts.\nI. safeguard the insulation.\nJ. avert overheating of the motor.\n\nIndicate the correct letter choice in \\boxed{X}, where X is the accurate letter choice. Limit the explanation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1379,7 +1379,7 @@
   {
     "global index": "MMLUPro_engineering_10473",
     "prompt": "Kindly survey the ensuing multiple-choice inquiries and furnish the most plausible accurate response based on the furnished alternatives.\n\nContext: None\n\nInquiry: A succinct dipole exhibits a radiation impedance R_r=\\surd(\\mu_0 / \\epsilon_0) [(\\betal)^2 / 6\\pi] ohms. Identify the utmost efficient aperture of this dipole.\n\nSelections: \nA. 0.075 \\lambda^2\nB. 0.200 \\lambda^2\nC. 0.180 \\lambda^2\nD. 0.089 \\lambda^2\nE. 0.102 \\lambda^2\nF. 0.119 \\lambda^2\nG. 0.134 \\lambda^2\nH. 0.145 \\lambda^2\nI. 0.160 \\lambda^2\nJ. 0.050 \\lambda^2\n\nRender the precise alphabetic selection in \\boxed{X}, where X symbolizes the correct alphabetic selection. Limit the elucidation or critique to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1388,7 +1388,7 @@
   {
     "global index": "MMLUPro_engineering_10537",
     "prompt": "Carefully examine the subsequent set of multiple-choice queries and select the answer that seems most accurate from the provided alternatives.\n\nScenario: Not specified\n\nProblem: Determine the energy accumulated in an inductor from time zero to one second, given its \\(\\phi\\)-characteristic as \\(\\phi(t) = \\frac{1}{3}i^3(t)\\) with a current described by \\(i(t) = 2 \\sin t\\).\n\nChoices:\nA. 1.00 Joules\nB. 0.75 Joules\nC. 1.50 Joules\nD. 4.00 Joules\nE. 2.50 Joules\nF. 3.00 Joules\nG. 1.25 Joules\nH. 2.75 Joules\nI. 2.00 Joules\nJ. 3.50 Joules\n\nIndicate the accurate letter answer in \\(\\boxed{X}\\), with \\(X\\) representing the correct selection. Limit the explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1397,7 +1397,7 @@
   {
     "global index": "MMLUPro_engineering_10701",
     "prompt": "Pleaz reed teh folowing muptiple-choise questons n provde teh most liekly corect anser based on teh opitons givn.\n\nContxt: None\n\nQuetsion: Fnd recusively teh seqence y [n] so that y [1] = 3, y [0] = 2, and y [n] - 3y [n - 1] + 2y [n - 2] = 0 ; n \\geq 2.\n\nOptons: \nA. y [n] = 5, 9, 15,...; n >= 2\nB. y [n] = 5, 9, 17,...; n >= 2\nC. y [n] = 2, 5, 9,...; n >= 2\nD. y [n] = 3, 5, 9,...; n >= 2\n\nProvde the corect leter choic in \\boxed{X}, wher X is teh corect leter choic. Kep teh explanaton or feeback wthin 3 senteces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1406,7 +1406,7 @@
   {
     "global index": "MMLUPro_engineering_10823",
     "prompt": "You are required to review these multiple-choice inquiries and select the answer most likely to be correct from the available options.\n\nScenario: None\n\nInquiry: The 8086/8088 processing cycle comprises four clock cycles: T1, T2, T3, T4, and an uncertain amount of wait state cycles labeled as Tw. These wait states are consistently introduced between\n\nSelections: \nA. T1 & T2\nB. T2 & T3\nC. T3 & T4\nD. T4 & T1\n\nEncapsulate the accurate letter choice in \\boxed{X}, where X signifies the correct option. Limit the rationale or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1415,7 +1415,7 @@
   {
     "global index": "MMLUPro_engineering_10864",
     "prompt": "Review the multiple-choice queries below and select the answer that seems most plausible from the provided choices.\n\nContext: None\n\nQuestion: Analyze a scenario involving forced convection inside a conduit. The local heat transfer coefficient is applicable precisely where it is measured and in its nearby region. When evaluating the entire pipe, the average heat transfer coefficient is relevant. The average temperature difference is calculated as (T_s - T)_av= [{{(T_s - T_in) + (T_s - T_out)}} / 2], where T_s represents the wall's surface temperature, T_in denotes the bulk fluid's temperature at the entry, and T_out signifies the bulk fluid's temperature at the exit. Discover the average heat transfer coefficient h_av expressed in terms of the local coefficient h_x.\n\nOptions:\nA. h_av= [{{^L\\int_0h_x(T_s - T)dx}} / 2\\piR^ L]\nB. h_av= [{{^L\\int_0h_x(T_s - T)dx}} / (T_s -T_av)]\nC. h_av= [{{^L\\int_0h_xdx}} / (T_s - T_av)]\nD. h_av= [{{^L\\int_0h_x(T_s - T)^2dx}} / (T_s - T_av)]\nE. h_av= [{{^L\\int_0h_x(T_s - T)dx}} / (T_s + T_av)]\nF. h_av= [{{^L\\int_0h_x(T_s - T)dx}} / (T_in - T_out)]\nG. h_av= [{{^L\\int_0(h_x + T)dx}} / (T_s - T_av)]\nH. h_av= [{{^L\\int_0h_x(T_s - T)dx}} / {{(T_s - T_in) + (T_s - T_out)}}]\nI. h_av= [{{^L\\int_0h_x(T_s + T)dx}} / (T_s -T_av)]\nJ. h_av= [{{^L\\int_0h_x(T_s - T)dx}} / L]\n\nChoose the correct option and write it as \\boxed{X}, where X is the correct letter choice. Limit the explanation to 3 sentences or less.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1424,7 +1424,7 @@
   {
     "global index": "MMLUPro_health_4885",
     "prompt": "Pleas reed teh folowing multipl-choice qestions an provide teh moost likely corect awsner bsaed on teh optoins givven.\n\nContex: Nnone\n\nQuestin: An 18-yer-old maan is broght to teh emergncy departmet 10 minues after he sustaind a stabwound to his chset. On arival, hee is unresponive to painfull stimli. His puls is 130/min, resirations ar 8/min an shalow, and palable systlic blood presure is 60 mm Hg. He is intubted an mechianically venilated, an infuson of 0.9% salne is begn. Aftr 5 minues, his puls is 130/min, an blood presure is 70/40 mm Hg. Examinaton show a 2-cm wond at th left sixth intercostal spce at th midclavicular lne. Ther is juglar venous distntion. Breath souds ar normal. Th trechea is at th midline. Hart souds ar not audble. Which of th folowing is th mst apropriate next stp in managemnet?\n\nOptoins: \nA. Pericrdiocentesis\nB. Perfrm a CT scan of th chset\nC. Thoracentessis\nD. Brnchoscopy\nE. Adminster morpine for pain managemnt\nF. Echocardiogaphy\nG. Chst x-ray\nH. Srugical exploraton of th wond\nI. Adminster intravenos antibitics\nJ. Adminster oxgen therpy\n\nProvide th corect leter choice in \\boxd{X}, wher X is th corect leter choice. Keep th explanaton or feedbak withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1433,7 +1433,7 @@
   {
     "global index": "MMLUPro_health_4973",
     "prompt": "Kindly examine the ensuing multiple-choice queries and determine the most probable accurate response from the selections presented.\n\nContext: None\n\nInquiry: Within the Latino population, which group faces the highest threat of HIV contraction?\n\nChoices:\nA. Medical practitioners\nB. Expectant mothers\nC. Substance users via injection\nD. Straight men\nE. Senior citizens\nF. People abstaining from sexual relations\nG. Plant-based diet followers\nH. Women\nI. Youths below 12 years\nJ. Men who engage in same-sex relations\n\nIndicate the correct option by inscribing \\boxed{X}, where X signifies the right choice. Restrict the rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1442,7 +1442,7 @@
   {
     "global index": "MMLUPro_health_5093",
     "prompt": "Carefully analyze the subsequent set of multiple-choice queries and select the option that most plausibly represents the correct answer from those provided.\n\nScenario: Not Applicable\n\nInquiry: Which research methodology offers the strongest evidence for the link between sugar consumption and the likelihood of developing dental cavities?\n\nSelections:  \nA. Case-control examination  \nB. Longitudinal analysis  \nC. Unrandomized controlled trial  \nD. Cross-sectional observational study  \nE. Experimental research  \nF. Comprehensive review  \nG. Descriptive study  \nH. Randomized controlled trial  \nI. Prospective cohort study  \nJ. Population-level analysis  \n\nReveal the justified letter selection in \\boxed{X}, specifying the accurate letter. Limit your rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1451,7 +1451,7 @@
   {
     "global index": "MMLUPro_health_5144",
     "prompt": "Kindly review the subsequent multiple-choice questions and select the option that most plausibly represents the correct response.\n\nContext: None\n\nQuestion: Under what circumstances does the production of lactate in muscles rise?\n\nOptions: \nA. when the muscle is optimally hydrated.\nB. when oxygen availability in the muscle is diminished.\nC. when glucose concentration in the muscle is depleted.\nD. when oxygen is abundantly accessible.\nE. when the muscle's pH decreases.\nF. when the muscle is in a state of rest.\nG. when pyruvate cannot be synthesized from glucose catabolism.\nH. when glycolysis is triggered at the commencement of physical activity.\nI. when the muscle endures an abrupt decrease in temperature.\nJ. when the muscle is relaxed.\n\nIdentify the appropriate letter choice in \\boxed{X}, where X represents the correct letter option. Limit any explanation or commentary to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1460,7 +1460,7 @@
   {
     "global index": "MMLUPro_health_5214",
     "prompt": "Kindly examine the ensuing multiple-choice inquiries and select the most plausible answer from the choices provided.\n\nContext: Absent\n\nInquiry: Which among the enumerated elements has garnered less endorsement than the others in studies exploring the link between social support and enhanced well-being?\n\nSelections: \nA. Physiological\nB. Behavioral\nC. Biological\nD. Anthropological\nE. Environmental\nF. Psychological\nG. Gerontological\nH. Neurological\nI. Social\nJ. Sociological\n\nIndicate the appropriate letter selection in \\boxed{X}, where X is the accurate letter choice. Limit the justification or remarks to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1469,7 +1469,7 @@
   {
     "global index": "MMLUPro_health_5215",
     "prompt": "Carefully examine the subsequent set of multiple-choice queries and select the answer that most likely aligns with the provided alternatives.\n\nContext: None\n\nQuestion: The predominant justification offered by both genders for the enduring nature of their marriage is\n\nOptions: \nA. Their union was prearranged\nB. They find consensus in nearly every matter\nC. Their faith is deeply rooted\nD. They preserve distinct social circles\nE. They consistently go on holidays together\nF. They share a mutual pastime or passion\nG. They are bound to honor their commitments\nH. They feel responsible for their offspring\nI. They consider each other closest companions\nJ. They reject the concept of separation\n\nPresent your answer in the format \\boxed{X}, where X indicates the accurate option. Limit any explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1478,7 +1478,7 @@
   {
     "global index": "MMLUPro_health_5261",
     "prompt": "Plesae raed teh folowing multipl-choise qestions annd provvide the most likly correcct anser based onn the optons gven.\n\nContxt: Nne\n\nQueston: If a blod unit hs ben out off refrigertion fr longer thn the aceped time limt, yu shuld:\n\nOptons: \nA. Use it fr non-hman transfsion purpses.\nB. Leav it to reach rom temprature bfore admnisterng.\nC. refrigrate fr a minmum of 12 houurs and then adinister it.\nD. retun it to the blod bank and infom them of why yu hav doen so.\nE. disopse of the contnts in the sluice areea, kepping the bag fr record purposs.\nF. Use it immdiately fr the most crtical patiet.\nG. Discrd it without notfying the bllod bank.\nH. Frze it to prsserve it fr later use.\nI. Rturn it to the refrigrator and use it wthin the next 24 hrs.\nJ. transfuse it as son as possibl and annotate the patiet's notes wth the tim of adinistration.\n\nProvde the correc leter choise in \\boxed{X}, whre X is the correc leter choise. Kp the explanatn or feeback wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1487,7 +1487,7 @@
   {
     "global index": "MMLUPro_health_5473",
     "prompt": "Plase read teh followng mupltiple-choice qestions nd proivde the msot likly corrcet asnwer bsaed on the optoins gvien.\n\nContxt: Non\n\nQueston: Teh pancreas scretes a lerge amunt of digestve enzyms aftera mal. Wich satement abot this proces is correkt?\n\nOptoins: A. Bile is neded to actvate al pancretic enzyms B. Al pancratic enzyms ar prduced in an actve form adn can strt digestion immeediatly C. Enzyms ar producd in the pancras but releasd in teh stomch for digestion D. Pepsinogen is teh cheif enzyem wich digests protien adn reqires removal of a peptde seqence frm teh actve cleft bfore it can work E. Pancretic scretion of hydrocloric acid is requird to provde the corct pH for maxmal pancratic enzyem in teh duodenum F. Enteropeptidase cnverts trypsinogen to trypsin by clevage of a peptde seqnce tht blcks the actve site of trypsin. G. Pancretic enzyms ar neded to brek down carbohydrats only. H. Pancreatic á-amylase wil hydrolise starh to fre glucos\n\nProvde teh corrcet leter choce in \\boxed{X}, wher X is the corect leter choce. Keap teh explantion or fedback wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1496,7 +1496,7 @@
   {
     "global index": "MMLUPro_health_5514",
     "prompt": "Pleas read the folowing multiple-choice questons and proviide the most likly corect anser based on the optoins gven.\n\nContex: None\n\nQueston: A 2-year-old boy is broght to the emergency departmnt by his babysiter becase of a 30-minut history of respirtory distres. The babysiter reprts that she is 15 years old and has cared for the patint on numerus occassions during the past yer. The child's mothr, who is a single parnt, is curently out of town for busines but will retur latr tonight. The babysiter says, \"he has had a runy nose sinse I started babysitting yesterdy, but this afternoon he awoke from a nap with a barkng sound and he was brething real hevvy.\" She does not knw the child's pior health history, nor does she knw if the boy takes any medicatins on a regulr basis. The child looks tired and sits uprigt on the babysiter's lap. He is obviosly comfortble with his caregivr. Vtal signs are temprature 38.7°C (101.7°F), pulse 110/min, respiratons 28/min and labored, and blood presure 85/50 mm Hg. Pulse oxmetry on rom air shows an oxgen saturtion of 89%. Physical examintion discloes inspiratory stridr. Neck is suppe, tympanic membrans are normal, and there is a profse nasal discharge. Examinaton of the pharynx discloes no abnormalties. Ausculttion of the chest discloes equal air entry on both sides and no crakles. The remander of the examnation shows no abnormalties. Treatmnt with 40% oxgen via venturi mask and intraveous fluids is initated. Despite continud supplemetal oxgen and hidraton, the child reamins tachypneic and stridrous at rest. Oxgen saturtion is now 93%. In additon to adminstering racemic epinephrin by nebulizr, wich of the folowing is the most apropriate next step?\n\nOptins: \nA. Intraveous aminophylline therpy\nB. Intraveous antibiotic therpy\nC. Intubtion\nD. Oral dexamethasone therpy\n\nProvde the corect leter choce in \\boxed{X}, whre X is the corect leter choce. Kep the explanaton or feedbak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1505,7 +1505,7 @@
   {
     "global index": "MMLUPro_history_4486",
     "prompt": "Please carefully examine the subsequent multiple-choice inquiries and identify the most plausible correct solution from the alternatives presented.\n\nContext: None\n\nQuestion: This inquiry pertains to the succeeding details.\nConsider the account of a female employed within the manufacturing sector of a Broadway establishment. This case typifies numerous similar instances. She earns an average of three dollars weekly. Her expenses include $1.50 for lodging; breakfast consists solely of coffee; lunch is beyond her means. She subsists on a solitary meal daily. This individual is youthful and attractive, with \"a world of possibilities ahead.\" Would it not be miraculous if she committed no greater folly than an \"early and rash marriage,\" which moral critics decry as a frequent source of impoverishment? Almost any opportunity might appear to offer liberation from such servitude. \"I feel significantly healthier since I began consuming three substantial meals daily,\" remarked a resident of one of the Girls' Homes. Two young seamstresses sought employment in domestic service to secure adequate sustenance. They had been undernourished for an extended period, and hunger compelled them to approach the one place an American-born girl's pride forbids, even if her independence costs her dearly.\n—Jacob Riis, How the Other Half Lives, 1890\nThe predicament of the young women described above is most analogous to which of the following?\n\nOptions: \nA. Jewish immigrants in New York in the 1880s\nB. Detroit autoworkers in the 1930s\nC. Populist farmers in the 1890s\nD. Factory workers in the Industrial Revolution\nE. British soldiers in the 1800s\nF. Coal miners in the 1900s\nG. Civil Rights activists in the 1960s\nH. Women suffragettes in the early 20th century\nI. American revolutionaries in the 1770s\nJ. Slaves in the antebellum South\n\nPresent the correct letter choice in \\boxed{X}, where X represents the accurate letter choice. Keep the explanation concise, within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1514,7 +1514,7 @@
   {
     "global index": "MMLUPro_history_4490",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response predicated on the enumerated selections.\n\nContext: Absent\n\nInquiry: This query pertains to the subsequent data.\n\"The inquiry, hence, warrants rapid resolution, whether liberated individuals of color, both native-born and naturalized within this nation, are indeed recognized as American nationals, and rightfully merit the entire spectrum of rights, advantages, and protections accorded to citizens across the various states; and whether the United States Constitution institutes or sanctions any unjust differentiation regarding the hue or status of liberated residents.\n\"Personally, I harbor not even the faintest uncertainty on the matter. My conviction is that the entitlements of liberated individuals of color merely require advocacy before the U.S. Supreme Court to be secured; that neither bias nor deceit . . . can obstruct their recognition . . . and that the extant statutes impacting your circumstances are patently unconstitutional. The reality that you have been regarded, by widespread consensus and routine practice, as outsiders and savages, does not validate such conduct as lawful, but merely illustrates the potency, acrimony, and ignorance of bias.\"\n—William Lloyd Garrison, \"To the Free People of Color of the United States,\" The Liberator, January 15, 1831\nThe proposition advanced by William Lloyd Garrison in the excerpt was subsequently refuted in which of the ensuing Supreme Court rulings?\n\nChoices: \nA. United States v. Nixon (1974)\nB. Miranda v. Arizona (1966)\nC. Gideon v. Wainwright (1963)\nD. Marbury v. Madison (1803)\nE. Brown v. Board of Education of Topeka (1954)\nF. Ex parte Milligan (1866)\nG. Roe v. Wade (1973)\nH. Plessy v. Ferguson (1896)\nI. McCulloch v. Maryland (1819)\nJ. Dred Scott v. Sanford (1857)\n\nRender the correct alphabetic selection in \\boxed{X}, where X denotes the correct choice. Limit the elucidation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1523,7 +1523,7 @@
   {
     "global index": "MMLUPro_history_4497",
     "prompt": "Kindly peruse the ensuing set of multiple-choice inquiries and offer the most plausible correct selection from the given possibilities.\n\nBackground: None\n\nInquiry: This query pertains to the subsequent details. Examine the enumeration of grievances below. Article 3: French citizens ought to acknowledge as statutory those decrees solely formulated by the national assembly and endorsed by the monarch. Article 11: Personal freedom, ownership entitlements, and the safety of individuals shall be articulated in a definitive, unambiguous, and irreversible way. All lettres de cachet are to be permanently eradicated, with certain adjustments at the discretion of the States General. Article 12: To eliminate perpetually any threat to the individual and property rights of the French populace, the jury system will be applied in all criminal proceedings, and in civil cases for fact-finding, throughout the judicial courts of the nation. Article 17: All disparities in sentencing shall be eradicated; offenses committed by citizens across different societal classes shall face equal punishment under uniform legal procedures and protocols. The States General shall endeavor to ensure that the repercussions of violations are confined to the perpetrator and not transferred to their innocent kin. Article 21: No levy shall be legitimate unless ratified by the representatives of the populace and sanctioned by the sovereign. —Cahiers of the Third Estate of Versailles, 1789 During the revolution's radical stage, which reform introduced by Robespierre was the LEAST advantageous to France's defense?\n\nChoices:\nA. Spreading revolutionary doctrines internationally\nB. Initiating the Reign of Terror\nC. Dismissing foreign envoys\nD. Pursuing a de-Christianization agenda\nE. Regulating prices and salaries\nF. Eradicating slavery in French territories\nG. Elevating soldiers based on battlefield performance\nH. Implementing strict food supply rationing\nI. Establishing a novel Republican Calendar\nJ. Mandating vast army enlistments\n\nIndicate the correct letter choice in \\boxed{X}, where X is the correct letter choice. Keep the explanation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1532,7 +1532,7 @@
   {
     "global index": "MMLUPro_history_4509",
     "prompt": "Kindly peruse the ensuing multiple-choice queries and select the most plausible accurate response from the options presented.\n\nContext: None\n\nQuery: What distinguishes an absolute date from a relative date?\n\nSelections: \nA. An absolute date signifies a static temporal point, whereas a relative date is adaptable and modifiable in relation to context.\nB. A relative date is inferred from radiometric dating methodologies, while an absolute date pertains solely to inscribed documents.\nC. An absolute date relies on the Gregorian calendar, whereas a relative date hinges on lunar cycles.\nD. A relative date signifies a specific year or span of years, contrasting with an absolute date that denotes a temporal sequence.\nE. A relative date is a timing calculable from an absolute date, whilst an absolute date cannot be inferred from a relative date.\nF. A relative date is an exact temporal instance, whereas an absolute date encompasses a broader time frame.\nG. An absolute date is universally recognized, while a relative date varies from 30 to 50 years.\nH. An absolute date denotes a specific year or range thereof, contrasting with a relative date that implies a sequential temporal progression.\nI. A relative date is ascertained through carbon dating, whereas an absolute date is conjectured via historical annals.\n\nSelect the accurate letter choice in \\boxed{A}, where A is the precise option. Retain the elucidation or critique within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1541,7 +1541,7 @@
   {
     "global index": "MMLUPro_history_4517",
     "prompt": "Pleese raed the folowing muiltiple-choce queastions and provid the most likley correect answr based on the optons given.\n\nConext: None\n\nQueastion: Ths queastion refers to the folowing infrmation.\n\"The far-reahing, the boundless futre will be the era of Americn greatnes. In its magnifcent domian of spae and time, the ntion of many natins is destned to manfest to manknd the exellence of dvine princples; to estabish on erth the nblest tempe ever dedcated to the worshp of the Most High—the Sacrd and the True. Its flor shall be a hemispher—its roof the firmamnt of the star-studded hevens, and its congrgation a Unin of many Republcs, comprsing hundrds of hapy milons, callng, ownng no man maaster, but govrned by God's natural and moral law of equlaity, the law of brothrhood—of 'pece and good will amngst men.'\"\nJohn L. O'Sullivan, \"The Great Ntion of Futurity,\" 1839\nBy what means did the United Stats take posession of the Oreogn Teritory?\n\nOptons: \nA. The United Stats anenxed it aftr a revol by Amercan settlrs livng in the teritory.\nB. The United Stats bouht it from the Native Americns who livd there.\nC. The teritory was divded betwen the United Stats and Cannda aftr a vote by resdents.\nD. U.S. settlrs were the frst to arive in the regon; they claimd it for their contry.\nE. The United Stats claimd it aftr discovring it druing an explration.\nF. The United Stats won it from Mexco in a war.\nG. The United Stats inheritd it from Spn as part of the Luisiana Purchse.\nH. Great Britan cedd it to the United Stats as part of a negtiated trety.\nI. The United Stats was graanted the teritory in a postwar trety with Frnce.\nJ. The teritory was giftd to the United Stats by Russa.\n\nProvde the correect leter choce in \\boxed{X}, where X is the correect leter choce. Kep the explnation or fedback within 3 sentnces.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1550,7 +1550,7 @@
   {
     "global index": "MMLUPro_history_4523",
     "prompt": "Pleese rad the folowing multi-choice qwestions an provid th most likly corect answr based on th optins givn.\n\nContext: None\n\nQuestin: This questn reffers to the folowing infrmation.\n\"Wheras it is expedient that new provissions an regulatons shuld be establisheed for improving th revenu of this kingdum, an for extnding an securing th navigatoin an commerse between Great Britan an yur Majesty's dominons in Amerca, which, by th peace, have been so hapily enlargd: an wheras it is just an necesary, that a revenu be raisd, in yur Majesty's said dominons in Amerca, for defraying the expenss of defnding, proecting, an securing the same; we, yur Majesty's most dutiful an loyl subjecs, the commons of Great Britan, in parliamnt assemled, being desirous to make som proision, in this presnt sesion of parliamnt, towards raising th said revenu in Amerca, hav resolvd to giv an grant unto yur Majestee the sevral rates an dutis hereaftr-mentiond….\"\nThe Sugar Act of 1764\nThe goals presnted in th xcerpt hav th most in common with whch of th folowing?\n\nOptins: \nA. Decreesing fedral incom tax rates in th 1980\nB. The econmec stimlus pacage during th 2008 financal crissis\nC. Th protecctive tarifffs establishedd during th Industrail Revolutoin\nD. The implementatoin of th Gold Standrd in th 19th centry\nE. The deregulatoin polices of th 1980s\nF. The establishemnt of th Fedral Resrve in 1913\nG. Free trade polices of th 1970s\nH. The New Deal's econmic polices during th Great Deprssion\nI. Antitrust reforms of th Progessive Era\nJ. Increasing fedral incom tax rates aftr World War I\n\n\nProvide th corect leter choise in \\boxed{X}, wher X is th corect leter choise. Keep th explenatoin or feedbak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1559,7 +1559,7 @@
   {
     "global index": "MMLUPro_history_4605",
     "prompt": "Kindly examine the ensuing multiple-choice inquiries and determine the most probable accurate response from the provided alternatives.\n\nContext: Absent\n\nQuestion: This inquiry pertains to the subsequent details.\n\"One or more of the [planet's] civilizations would need to significantly amplify its output [to attain worldwide dominance]. This substantial surge must occur preceding the assorted scientific, technological, agricultural, and industrial upheavals that underpin our post-leap society. Achieving this could only happen by harnessing the biospheres, mineral wealth, and human resources of entire continents beyond the territories of the society executing the leap. Western Europe accomplished this through its ferocity and weaponry, and more crucially, due to geographical and ecological fortune.\"\nCopyright © 2015 Cambridge University Press.\nAlfred Crosby, historian, Ecological Imperialism, 2004\nWhich of the following would most effectively corroborate the author's claim about the \"substantial surge\" aiding Western Europe in securing global dominance between 1450 and 1750 C.E.?\n\nOptions: \nA. The unearthing and settlement of Australia\nB. The cultural interchange with Indigenous American tribes\nC. The evolution of a unified administration in Europe\nD. The overhaul of Catholic Christianity\nE. The subjugation of the Aztec Empire\nF. The mechanized transformation in Britain\nG. The seclusion of Tokugawa Japan\nH. The occupation of Africa's interior\nI. The building of the Great Wall of China\nJ. The initiation of trade routes with China\n\nIndicate the accurate letter selection in \\boxed{X}, where X is the correct letter selection. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1568,7 +1568,7 @@
   {
     "global index": "MMLUPro_history_4629",
     "prompt": "Kindly peruse these multiple-choice inquiries and determine the most plausible proper response from the furnished selections.\n\nContext: None\n\nInquiry: This query pertains to the subsequent details.\nI stroll beside the convoy, inquiring about the situation.\nA combatant tersely remarks: \"They're enlisting more daily.\n\"Some of us were dispatched north to the Yellow River at fifteen years old,\nAnd now at forty, we're bound for western garrisons.\nDuring our initial deployment, the village leader had to fasten our headbands.\nUpon returning, our hair had turned gray, yet turmoil persisted.\nThe frontier outposts are awash with blood, sufficient to fill a sea,\nBut the Martial Sovereign's land-hunger remains unquenched.\nIn the myriad districts east of the ranges, within the Han domain,\nThere might be ten thousand hamlets overrun by brambles.\nEven if spouses are robust enough to wield a hoe and plough,\nThe produce grows haphazardly, the terrain is chaotic.\nIt's most burdensome for the Shanxi folk, famed as warriors:\nThey're rounded up like livestock, every male conscripted.\n\"But sir, though it's considerate of you to inquire,\nGrumbling doesn't suit a soldier's duty.\nWe can merely shake our heads. Observe this winter:\nThe Shanxi forces were kept from returning home.\nThe District Officials demand the land levy,\nBut from where shall it emerge? One can't extract blood from a stone!\nI sincerely believe it's ill fortune to father a son now,\nIt's preferable to have a daughter: she might wed\nAnd live with the neighbors nearby.\nYet a son might wind up on some far-off steppe.\"\nDu Fu, \"Ballad of the Army Carts,\" circa 750 C.E.\nWhich among the following does the poem offer direct proof for regarding taxation in the third stanza?\n\nChoices: \nA. The Tang Dynasty's vast, continuous professional military with no conscription requirement\nB. The Tang Dynasty's just and impartial tax system\nC. Comparatively progressed Tang agronomic methods\nD. The Tang Dynasty's robust administrative framework at the local tier\nE. The Tang Dynasty's affluence due to high taxes\nF. The Tang Dynasty's scarcity of regular income due to unsettled levies\nG. The Tang Dynasty's land allocation method based on taxation\nH. The Tang Dynasty's substantial dependence on conscription to fulfill military needs\nI. The Tang Dynasty's obligatory labor system in place of taxation\nJ. The relatively elevated urbanization level in Tang China\n\nIndicate the correct letter choice in \\boxed{X}, where X is the correct letter choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1577,7 +1577,7 @@
   {
     "global index": "MMLUPro_history_4638",
     "prompt": "Kindly scrutinize the ensuing multiple-choice inquiries and select the most plausible accurate response from the enumerated alternatives.\n\nContext: None\n\nInquiry: The subsistence methodologies of communities can be ascertained through recovering and scrutinizing:\n\nAlternatives: \nA. geological strata and sediment categories.\nB. the structural design and spatial configuration of edifices on the location.\nC. volcanic ash and proof of pyroclastic flows.\nD. the collection of animal remains from a location.\nE. an osteological comparative assemblage from a location.\nF. indications of previous volcanic phenomena.\nG. every aforementioned option.\nH. historical manuscripts and records pertinent to the location.\n\nRender the correct letter selection in \\boxed{X}, where X signifies the accurate letter selection. Restrain the elucidation or commentary to within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1586,7 +1586,7 @@
   {
     "global index": "MMLUPro_history_4717",
     "prompt": "Kindly review the ensuing set of multiple-choice inquiries and identify the most plausible correct response from the options provided.\n\nContext: None\n\nQuestion: This inquiry pertains to the subsequent information.\n\"Truly, as both the rulings of esteemed [scholars] who ground their views equally in logic and tradition and the agreement of the Sunni community assert that the time-honored duty of eradicating, annihilating, and banishing malevolent innovation must be the target of our noble ambition, for \"Religious fervor signifies a triumph for the Religion of God the Merciful\"; thus, following the sayings of the Prophet (Peace be upon him!) \"Whoever introduces malevolent innovation into our system must be removed\" and \"Whoever does anything against our system must be removed,\" measures have become imperative and urgent…\"\nCorrespondence from Ottoman Sultan Selim I to Safavid Shah Ismail I, 1514\nThe primary reason for the Safavids inciting the animosity of Islamic empires such as the Ottoman and Mughal Empires was that the Safavids\n\nOptions: \nA. possessed a more sophisticated military than the Ottoman and Mughal Empires\nB. were an expansionist empire situated between two other expansionist powers\nC. advocated polytheism, contradicting the beliefs of the Ottoman and Mughal Empires\nD. were charged with blasphemy by the Ottoman and Mughal Empires\nE. Ismail declared himself to be a Caliph\nF. declined to render tributes to the Ottoman and Mughal Empires\nG. adhered to a divergent sect of Islam\nH. allied themselves with the adversaries of the Ottoman and Mughal Empires\nI. repudiated the core principles of Islam\nJ. captured Christians, converting them into Safavid combatants\n\nSelect the correct letter choice in \\boxed{X}, where X is the correct letter choice. Limit explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1595,7 +1595,7 @@
   {
     "global index": "MMLUPro_history_4749",
     "prompt": "Kindly examine these multiple-choice queries and select the most plausible answer from the provided selections.\n\nContext: None\n\nInquiry: The following question pertains to the subsequent details.  \n\"My small urban property, recently covered by a £2,000 insurance policy, would likely have met a similar fate, as insurance firms refuse to compensate for losses inflicted by the Queen's adversaries. Moreover, though I possess a 50-acre farm near the city, it's probable the harvests and buildings have suffered damage. Indeed, this has partially occurred, prompting me to pursue legal action against the Government for the destruction caused by a group of 1,500 locals who have set up camp nearby, wreaking havoc in the vicinity.\"  \nCorrespondence from a British national to his sibling amidst the Anglo-Zulu War, South Africa, 1879  \nEvents akin to those depicted in the letter were leveraged by the British authorities to accomplish which of the following?\n\nChoices:  \nA. Justify a declaration of war against the Zulu Kingdom  \nB. Forge a pact with the Zulu Kingdom against other tribal groups  \nC. Impose levies on the Zulu Kingdom to compensate for attributed damages  \nD. Compel British subjects to exit South Africa  \nE. Grant self-governance to the South African territories  \nF. Broker a peace accord with the Zulu Kingdom  \nG. Bolster military deployment in South Africa  \nH. Free the Zulu people from British rule  \nI. Relinquish duty to safeguard citizens residing in South Africa  \nJ. Initiate additional colonization in South Africa  \n\nIndicate the accurate letter choice in \\boxed{X}, where X is the correct letter choice. Limit your reasoning or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1604,7 +1604,7 @@
   {
     "global index": "MMLUPro_history_4752",
     "prompt": "Examine the following questions, selecting the answer you deem most accurate from the given choices.\n\nContext: None\n\nInquiry: This question pertains to the following information.\n\"Recently, the spontaneous dynamics of capitalism have been making headway in rural areas, with affluent peasants emerging and numerous moderately prosperous peasants aspiring to wealth. Conversely, many impoverished peasants remain destitute due to inadequate productive resources, with some incurring debt and others parting with or leasing their land. Should this trend persist unchecked, rural disparity will escalate progressively. Dispossessed peasants and those in persistent poverty will lament our inaction in rescuing them from destitution or aiding them in overcoming hardships. Furthermore, moderately prosperous peasants pursuing capitalist objectives will not be satisfied with us, for we cannot meet their expectations without embarking on a capitalist path. Can the worker-peasant partnership endure under these conditions? Clearly, it cannot! The resolution lies in a fresh foundation. This entails progressively introducing socialist reform across agriculture while gradually actualizing socialist industrialization and transformation of handicrafts and capitalist trade practices; essentially, it involves implementing cooperation and phasing out the affluent-peasant economy along with individual rural economic practices so that all villagers advance collectively. We assert this is the sole means to solidify the worker-peasant partnership.\"\nMao Zedong, On the Question of Agricultural Co-operation, 1955\nMao's perspective on peasant labor collaboration predominantly mirrors the impact of which of the following?\n\nAlternatives: \nA. The principles of communism as articulated by Joseph Stalin\nB. The tenets of democratic socialism as articulated by Salvador Allende\nC. The doctrines of social democracy as promoted by Bernie Sanders\nD. The concepts of globalization as exemplified by international trade alliances like NAFTA or the European Union\nE. The tenets of religious fundamentalism as articulated by Ayatollah Khomeini\nF. The theories of capitalism as expounded by Milton Friedman\nG. The precepts of classical liberalism as articulated by Adam Smith\nH. The principles of nationalism as evidenced by the emergence of populist movements in the 21st century\nI. The ideals of the Enlightenment as articulated by revolutionary figures such as Maximilian Robespierre\nJ. The tenets of fascism as articulated by Benito Mussolini\n\nIndicate the correct choice in \\boxed{A}, where A is the accurate selection. Keep the reasoning concise, within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1613,7 +1613,7 @@
   {
     "global index": "MMLUPro_history_4774",
     "prompt": "Carefully examine the subsequent set of multiple-choice inquiries and identify the most plausible correct response from the provided selections.\n\nContext: Not applicable\n\nInquiry: This query pertains to the ensuing excerpt.\n\"We discovered that it was not merely an internal conflict, a struggle by a populace long yearning to free themselves from any colonial dominance, but also that the Vietnamese, whom we had zealously shaped in our own likeness, found it challenging to confront the peril we purportedly shielded them from.\n\"We observed that the majority were unaware of the distinction between communism and democracy. Their sole desire was to cultivate rice fields without helicopters bombarding them and incendiary bombs ravaging their villages and dismembering their nation. They wished for the war's entirety, especially the foreign presence of the United States of America, to vacate their land, allowing them tranquility, and they honed their survival skills by aligning with whichever military faction was currently dominant, be it Viet Cong, North Vietnamese, or American.\"\nJohn Kerry, 1971\nThe two political issues that most troubled the Counterculture Movement of the 1960s were\n\nChoices: \nA. the civil rights movement and environmentalism\nB. the women's rights movement and censorship\nC. the civil rights movement and censorship\nD. flag desecration and the draft\nE. American engagement in Vietnam and flag desecration\nF. American engagement in Vietnam and the women's rights movement\nG. American engagement in Vietnam and environmentalism\nH. American engagement in Vietnam and the civil rights movement\nI. the draft and the environmental cause\nJ. censorship and the draft\n\nIndicate the accurate letter choice in \\boxed{X}, where X is the appropriate letter option. Restrict the explanation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1622,7 +1622,7 @@
   {
     "global index": "MMLUPro_history_4810",
     "prompt": "Kindly review the subsequent multiple-choice items and determine the most plausible correct response from the alternatives provided.\n\nContext: None\n\nInquiry: This question pertains to the accompanying passage.\n\"We assert that, within public education, the principle of \"separate but equal\" is unacceptable. Segregated educational institutions are fundamentally unequal. Consequently, we affirm that the plaintiffs and others in similar circumstances, for whom these proceedings have been initiated, are, due to the segregation in question, denied the equal protection of the laws as ensured by the Fourteenth Amendment.\"\nBrown v. Board of Education, 1954\nThe desegregation of educational institutions was partly driven by unmet promises from which of the following endeavors?\n\nChoices: \nA. The New Deal\nB. The Fair Deal\nC. The New Frontier\nD. Reconstruction\nE. The Square Deal\nF. The Great Society\nG. The Progressive Era\nH. The War on Poverty\nI. The Emancipation Proclamation\nJ. The Civil Rights Act\n\nIndicate the correct letter choice in \\boxed{X}, where X is the accurate letter choice. Limit the explanation or feedback to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1631,7 +1631,7 @@
   {
     "global index": "MMLUPro_history_4833",
     "prompt": "Carefully examine these multiple-choice queries and determine the most plausible accurate response from the provided selections.\n\nContext: None\n\nQuestion: Tiwanaku, with its hub located at Titicaca, was among the ___________ realms of antiquity.\n\nOptions: \nA. vastest\nB. densest\nC. earliest\nD. least recognized\nE. wealthiest\nF. most impactful\nG. most serene\nH. mightiest\nI. loftiest\nJ. most sophisticated\n\nSelect the correct letter choice in \\boxed{X}, where X is the correct letter choice. Keep the explanation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1640,7 +1640,7 @@
   {
     "global index": "MMLUPro_history_4836",
     "prompt": "Kindly peruse the ensuing set of multiple-choice inquiries and determine the most plausible accurate response from the selections presented.\n\nContext: None\n\nInquiry: Which among the following signifies a pivotal alteration in hominids initiating at least from the era of Homo erectus, plausibly linked to progressively enlarged cerebral capacity?\n\nSelections: \nA. skull size diminishment\nB. reduced tooth size\nC. small-headedness\nD. brow ridge cortex\nE. brain expansion\nF. grasping digits\nG. facial projection\nH. youthful traits retention\nI. upright walking\nJ. augmented body magnitude\n\nSubmit the precise alphabetical selection in \\boxed{X}, where X represents the correct choice. Limit the elucidation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1649,7 +1649,7 @@
   {
     "global index": "MMLUPro_history_4841",
     "prompt": "Examine the subsequent multiple-choice queries and select the answer that most plausibly aligns with the provided choices.\n\nContext: None\n\nInquiry: This query pertains to the subsequent excerpt.\n\"Should anyone, subsequent to the enactment of this legislation, forcibly and violently abduct, or orchestrate the abduction, and through deception or false representation, entice, or attempt to entice, any individual of African or mixed heritage, from any region within this commonwealth to any other location outside this jurisdiction, with the intent of selling, disposing of, or causing such persons to be held as servants or slaves indefinitely or for any duration, such individuals, along with their accomplices, upon being convicted in any competent court within this commonwealth, shall be adjudged as felons.\"\n—Segment from Pennsylvania statute, 1826\nThe enactment and enforcement of this Pennsylvania statute signified an enduring struggle between\n\nChoices:\nA. advocates and adversaries of governmental control over trade.\nB. the interests of countryside and city areas.\nC. the judiciary and the collective moral conscience.\nD. those supporting the abolition of slavery and those desiring to uphold the current system.\nE. national law versus state legislation.\nF. fiscal priorities and compassion-driven concerns.\nG. the Northern and Southern states regarding slavery.\nH. the doctrines of capitalism versus socialism.\nI. proponents of slow liberation and those advocating for immediate freedom.\nJ. personal liberties versus state authority.\n\nIndicate the accurate letter choice in \\boxed{X}, where X is the precise letter selection. Keep the rationale or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1658,7 +1658,7 @@
   {
     "global index": "MMLUPro_law_1007",
     "prompt": "Kindly examine the ensuing multiple-choice inquiries and determine the most plausible correct option based on the alternatives presented.\n\nScenario: None\n\nInquiry: Rainbow Corporation possesses 1,000 shares of voting common stock alongside 1,000 shares of nonvoting preferred stock. The preferred stock includes a liquidation preference equivalent to its $100 per share par value plus a 3% noncumulative dividend. Rainbow proposes to its shareholders to authorize a new category of preferred stock with redemption rights that would take precedence over the existing preferred stock. During a shareholders' assembly, 700 common and 400 preferred shares are voted in favor of the proposal. Which assertion is correct?\n\nChoices: \nA. The proposal lacks valid approval as a unanimous vote from both categories is necessary.\nB. The proposal gains valid approval since the nonvoting preferred stock is excluded from the vote.\nC. The proposal lacks valid approval because a two-thirds vote from each category is required.\nD. The preferred stockholders' vote holds no significance as it was nonvoting stock.\nE. The proposal gains valid approval since the common shareholders possess the majority vote.\nF. The preferred stockholders' vote holds no significance as the proposal impacts the common stock.\nG. The proposal gains valid approval as the preferred stockholders favoring it possess a liquidation preference.\nH. The proposal lacks valid approval as a majority of the outstanding shares did not approve.\nI. The proposal lacks valid approval as a majority of the preferred shareholders did not approve.\nJ. The proposal gains valid approval as, in totality, a majority of the outstanding shares did approve.\n\nIndicate the correct letter choice in \\boxed{X}, where X represents the accurate letter choice. Maintain the explanation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1667,7 +1667,7 @@
   {
     "global index": "MMLUPro_law_1031",
     "prompt": "Kindly peruse the ensuing multiple-choice queries and determine the most plausible accurate answer from the presented selections.\n\nContext: None\n\nInquiry: Which among the statements listed is untrue?\n\nSelections: \nA. During the 1990s, it became evident that the European Court of Human Rights required reform due to a decline in member state numbers.\nB. During the 1990s, it became evident that the European Court of Human Rights required reform as it was not effectively enforcing its rulings.\nC. During the 1990s, it became evident that the European Court of Human Rights required reform for its failure to assess a sufficient volume of cases.\nD. During the 1990s, it became evident that the European Court of Human Rights required reform owing to the increased number of individuals able to access the Court following a rise in member states.\nE. During the 1990s, it became evident that the European Court of Human Rights required reform as it struggled to keep pace with swift changes in international law.\nF. During the 1990s, it became evident that the European Court of Human Rights required reform because of a surge in workload.\nG. During the 1990s, it became evident that the European Court of Human Rights required reform due to substantial political pressure.\nH. During the 1990s, it became evident that the European Court of Human Rights required reform because it operated on a part-time basis, unable to manage the increasing volume of complaints.\nI. During the 1990s, it became evident that the European Court of Human Rights required reform due to insufficient diversity among its judiciary.\nJ. During the 1990s, it became evident that the European Court of Human Rights required reform owing to financial limitations.\n\nIndicate the correct letter choice in \\boxed{X}, where X represents the accurate letter option. Keep the explanation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1676,7 +1676,7 @@
   {
     "global index": "MMLUPro_law_1386",
     "prompt": "Kindly peruse the ensuing array of multiple-choice inquiries and select the most probable accurate response from the options proffered.\n\nScenario: None\n\nInquiry: An academic scholar, domiciled in State A, asserts that her educational institution contravened federal statutes when it ceased allocations for the women's varsity volleyball squad. She has initiated litigation against the university, a charitable entity situated and established in State B, along with the university's athletics overseer, a resident of State B, within a federal tribunal situated in State B. What constitutes the optimal approach for effectuating service upon the defendants?\n\nSelections: \nA. Notification via a widely circulated State B periodical.\nB. Notification conforming to State B's judicial procedure mandates.\nC. Notification through electronic mail, dispatching the summons and complaint to the athletics overseer and university chancellor.\nD. Notification via facsimile transmission of the summons and complaint to the athletics overseer and university chancellor.\nE. Notification executed personally by the student upon the athletics overseer and university chancellor.\nF. Notification via a process server depositing summons and complaint duplicates with administrative aides in the respective offices of the athletics overseer and university chancellor.\nG. Notification by the scholar's legal representative upon the athletics overseer and university chancellor.\nH. Notification through transmission of summons and complaint duplicates via the university's internal postal system.\nI. Notification by depositing summons and complaint duplicates at the university's primary ingress.\n\nIndicate the correct letter selection in \\boxed{X}, where X is the correct letter selection. Limit the justification or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1685,7 +1685,7 @@
   {
     "global index": "MMLUPro_law_1462",
     "prompt": "Pleese raed teh folowing multple-choise questons and provde teh most likley corect answr based on teh optons gven.\n\nContext: None\n\nQueston: On Septeber 15, a card shp snt teh folowng faax to a prnting cmpany: \"Pleese delivr 100 dozn assrted Chrstmas crds, delivry by Novmber 1.\" On Octber 10, the prntng cmpany shiped 100 dozn assrted Thanksgivng crds to teh card shp, whch wre receved on Octber 12. Teh folowing day, the card shp snt teh folowng faax to teh prntng cmpany: \"Be advsed that yuor shipment is rejcted. Ordr stipulated Chrstmas crds, nt Thanksgivng crds.\" On Octber 15, teh prntng cmpany snt teh folowng faax to teh card shp: \"Wll ship 100 dozn assrted Chrstmas crds by Novmber 1. Pleese ship teh Thanksgivng crds bak to our warhouse and bill us for teh shiping chargs.\" Ths faax was receved by teh card shp, but the card shp did nt respond to it or ship teh Thanksgivng crds bak to teh prnntng cmpany. On Octber 25, teh prntng cmpany atemptd to delivr 100 dozn assrted Chrstmas crds to teh card shp, but teh lattr refsed to acpt. Did teh card shp properly rejct teh Octber 25 delivry?\n\nOptons: \nA. No, beecaus teh card shp did not explcitly agre to teh modifed ofr from teh prnting cmpany.\nB. No, beecaus teh prntng cmpany cured teh Octber 10 defectiv shipment by its tendr of conforming goods on Octber 25.\nC. Yes, beecaus teh prntng cmpany's shiping of teh Thanksgivng crds on Octber 10 constituted a present breach of cntract.\nD. Yes, beecaus teh card shp ws not obligted to acpt teh secnd shipment of Chrstmas crds.\nE. No, beecaus undr teh UCC a cntract for teh sale of goods cn be modifid wthout considration.\nF. Yes, beecaus teh prntng cmpany did nt delivr teh corect ordr initally as reqested by teh card shp.\nG. Yes, beecaus teh card shp had alredy rejcted teh inital shipment of Thanksgivng crds.\nH. Yes, beecaus teh prntng cmpany's shiping of teh Thanksgivng crds on Octber 10 constituted an anticiptory breach.\nI. No, beecaus teh card shp did nt return teh Thanksgivng crds as reqested by teh prntng cmpany.\n\nProvde teh corect leter choce in \\boxed{X}, whre X is teh corect leter choce. Kep teh explanaton or fedbck wthn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1694,7 +1694,7 @@
   {
     "global index": "MMLUPro_law_1484",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and select the answer that appears most plausible based on the available alternatives.\n\nSetting: None\n\nInquiry: A jurisdiction enforces a tiered levy on income derived pursuant to federal statutes. Article 22 of the municipality's overhaul statute from 2010, effective from January 1, 2010, stipulates: \"Any caregiver or custodian fiscally accountable for the schooling of their charge may assert a direct fiscal credit against their income tax obligation equivalent to the tuition sum for a youth or youths of secondary school age not enrolled in a state secondary institution.\" Additional clauses expansively interpret \"tuition\" yet confine the credit to fees remitted to academies satisfying the pedagogical criteria as assessed by the jurisdiction. On December 1, 2009, the guardians of two pupils attending a state secondary institution initiate litigation for a declaratory decree and injunction in federal tribunal, contending that Article 22 contravenes the establishment clause of the First Amendment. The federal tribunal will most plausibly\n\nChoices:\nA. sustain the motion, as the jurisdictional statute prejudices against state school learners.\nB. reject the motion, as the litigation pertains to a governmental query.\nC. sustain the motion, as the claimants possess a legitimate assertion under the First Amendment.\nD. reject the motion, as the claimants have endured no tangible detriment.\nE. reject the motion, as the claimants lack standing in their capacity as taxpayers.\nF. sustain the motion, as the jurisdictional statute encroaches upon the guardians' prerogative to opt for a state institution.\nG. reject the motion, as the matters under litigation are moot.\nH. reject the motion, as the matters are not ripe.\nI. reject the motion, as the litigation exceeds the ambit of the federal tribunal.\nJ. reject the motion, as the jurisdictional statute does not infringe upon the establishment clause of the First Amendment.\n\nIdentify the appropriate letter selection in \\boxed{X}, where X is the suitable letter selection. Restrict the elucidation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1703,7 +1703,7 @@
   {
     "global index": "MMLUPro_law_1518",
     "prompt": "Kindly review the subsequent multiple-choice questions and identify the most plausible correct answer from the options presented.\n\nIn a scenario where a husband is accused of murdering his brother-in-law through a shooting, the legal system in which he is being tried recognizes insanity as an affirmative defense. The husband claims insanity as his defense strategy. At the trial, to validate his insanity defense, the husband must:\n\nOptions:\nA. assume neither the burden of production nor persuasion.\nB. fulfill the burden of proof beyond a reasonable doubt.\nC. carry the burden of production.\nD. establish a record of mental illness.\nE. present significant evidence of his insanity at the time of the offense.\nF. submit expert medical testimony.\nG. demonstrate his innocence.\nH. persuade the jury of his mental disorder.\nI. bear only the burden of persuasion.\n\nSelect the correct option in \\boxed{X}, where X denotes the correct letter choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1712,7 +1712,7 @@
   {
     "global index": "MMLUPro_law_1818",
     "prompt": "Pleas reed teh folowing multiple-choise questons an provied teh mos likely corect answr baseed on teh opions givn.\n\nContex: Nne\n\nQueston: A grantr is teh fee simpl ownr of a 1,000-acr trak of land. Haf of teh trak is swampland totlly unfit for cultvtion, thogh it is hevily covred wit valuabl hardwod timber. The othr haf is also covred wit valuabl timbr, but it is land that wud be fit for teh raisng of crops if it wer cleard of teh timbr. The latr secton of land is mor valuabl for cultvtion thn it is for teh growing of timbr. The grantr conveyd his trak to his brothr for life. At teh tim of teh conveance, teh swampland had nevrr ben usd for teh producton of timbr. The brothr took possesson an cleard 40 acres of teh timbr on teh secton that was suitabl for cultvtion. In addtion, teh brothr cut 60 acres of timbr in teh swampland, ths becming teh first persn to exploi this area. The brothr's cuting of teh timbr on teh secton of trak suitabl for cultvtion wud be an exmple of\n\nOptons: \nA. unreasonabl explotation.\nB. intntional wast.\nC. constrctive wast.\nD. amelorative wast.\nE. neglignt wast.\nF. voluntarr wast.\nG. remedial wast.\nH. permissive wast.\nI. equitabl wast.\n\n\nProide teh corect leter choise in \\boxed{D}, wher X is teh corect leter choise. Kep teh explanaton or feeback witin tree sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1721,7 +1721,7 @@
   {
     "global index": "MMLUPro_law_806",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the most plausible correct response from the provided choices.\n\nContext: None\n\nInquiry: What explanation most effectively outlines Hart's differentiation between 'being obliged' and 'having an obligation'?\n\nSelections: \nA. It challenges the perspective of natural law advocates regarding morality's influence on legal systems.\nB. It elucidates the notion of a regulation.\nC. It distinguishes between procedural and substantive fairness.\nD. It emphasizes the significance of personal rights within legal frameworks.\nE. It clarifies the association between legislation and community.\nF. It expounds on the essence of authority-conferring norms.\nG. It separates judicial and moral duties.\nH. It offers guidance for the implementation of laws.\nI. It describes the function of judicial judgment in legal matters.\n\n\nSelect the accurate letter selection in \\boxed{X}, where X represents the correct letter. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1730,7 +1730,7 @@
   {
     "global index": "MMLUPro_law_899",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the most plausible correct response from the provided alternatives.\n\nScenario: None\n\nInquiry: A state constructed a specialized racetrack tailored exclusively for thoroughbred horse racing. Bonds were issued by the state to fund this racetrack's development. The bond contract stipulated that in the racetrack's initial five years, a minimum of $2 from each admission ticket would be allocated to repaying the bond debt. Furthermore, it specified that if the income from admission fees during this period was inadequate to satisfy the bondholders, then at least $1 from each ticket over the succeeding five years would be dedicated to bond payments. After two years of operation, the state legislature enacted legislation mandating that senior citizens above 65 years be admitted at a reduced fee of 50 cents. This statute is likely\n\nChoices: \nA. unconstitutional, as it denies individuals below 65 equal legal protection.\nB. constitutional, as it promotes social welfare by offering discounts to the elderly.\nC. unconstitutional, due to age-based discrimination.\nD. constitutional, since the state can modify admission fees.\nE. unconstitutional, breaching bondholders' rights.\nF. unconstitutional, contravening the state's bond repayment duty.\nG. constitutional, with the state entitled to regulate internal commerce.\nH. unconstitutional, as it constitutes an ex post facto law.\nI. unconstitutional, impairing the bondholders' contract obligations.\nJ. constitutional, justified as an exercise of the state's police authority.\n\nIndicate the correct answer by marking \\boxed{X}, where X represents the appropriate choice. Limit the rationale or commentary to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1739,7 +1739,7 @@
   {
     "global index": "MMLUPro_math_6429",
     "prompt": "Pleaz read teh folowing mulitple-choise qestions an proide the most likel correct answr basd on teh optons givn.\n\nContext: None\n\nQestion: Statemnt 1 | Ther exsts a fre abelin grup of evry positiv integar rank. Statemnt 2 | A finitely genrated abelin grup is fre abelin if its Betti numbr eqals the numbr of elments in some genratng set.\n\nOptons: \nA. Flase, Flase\nB. Treu, Cannnot be determind\nC. Flase, Treu\nD. Cannnot be determind, Treu\nE. Flase, Cannnot be determind\nF. Statemnt 1 is flase for certan positve inteegers, Statemnt 2 is flase\nG. Treu, Flase\nH. Statemnt 1 is treu only for certan positve inteegers, Statemnt 2 is treu\nI. Cannnot be determind, Flase\nJ. Treu, Treu\n\nProide the corect leter choise in \\boxed{X}, wher X is the corect leter choise. Kepp the explantion or feadback withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1748,7 +1748,7 @@
   {
     "global index": "MMLUPro_math_6526",
     "prompt": "You are requested to examine the subsequent multiple-choice items and select the option that most accurately aligns with the truth.\n\nContext: None\n\nQuestion: Assertion 1 | The identity element in a subring coincides with the identity element of its encompassing ring. Assertion 2 | Every field qualifies as an integral domain.\n\nChoices: \nA. True, True\nB. Insufficient Information, True\nC. False, True\nD. Insufficient Information, False\nE. False, False\nF. True, False\nG. True, True if the field is finite\nH. Insufficient Information, Insufficient Information\nI. True, Insufficient Information\nJ. False, Insufficient Information\n\nProvide the correct choice in \\boxed{X}, where X denotes the accurate choice. Restrict the explanation or feedback to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1757,7 +1757,7 @@
   {
     "global index": "MMLUPro_math_6623",
     "prompt": "Kindly examine the subsequent multiple-choice queries and determine the most probable accurate response from the options presented.\n\nScenario: None\n\nInquiry: Select a single card indiscriminately from a typical deck. The sample universe $S$ encompasses all 52 cards. Suppose the probability function allocates $1 / 52$ to each of these 52 events. Define  \n$$\n\\begin{{aligned}}\nA & =\\{{y: y \\text {{ represents a jack, queen, or king }}\\}}, \\\\\nB & =\\{{y: y \\text {{ signifies a }} 9,10, \\text {{ or jack and }} y \\text {{ is colored red }}\\}}, \\\\\nC & =\\{{y: y \\text {{ denotes a club }}\\}}, \\\\\nD & =\\{{y: y \\text {{ indicates a diamond, a heart, or a spade }}\\}} .\n\\end{{aligned}}\n$$  \nCalculate $P(A)$\n\nChoices:  \nA. $\\frac{{14}}{{52}}$  \nB. $\\frac{{12}}{{52}}$  \nC. $\\frac{{13}}{{52}}$  \nD. $\\frac{{15}}{{52}}$  \nE. $\\frac{{10}}{{52}}$  \nF. $\\frac{{7}}{{52}}$  \nG. $\\frac{{11}}{{52}}$  \nH. $\\frac{{9}}{{52}}$  \nI. $\\frac{{8}}{{52}}$  \nJ. $\\frac{{16}}{{52}}$  \n\nSelect the correct option in \\boxed{X}, where X signifies the accurate letter selection. Restrict the rationale or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1766,7 +1766,7 @@
   {
     "global index": "MMLUPro_math_6848",
     "prompt": "Pleese reead the followin multple-choice qestions and provied the most likley corect anser based on teh opions givn.\n\nContext: None\n\nQuestion: An experinent iz to be condcuted to determne whther takng fish oill capsuules or galric capusles has moar of an efect on chlorestrol levles. In past studes it was notted that daly exrcise intesity (low, modrate, high) is asociated with chlorestrol levle, but avrge slep lenth (< 5, 5 - 8, > 8 hours) is not asociated with chlorestrol levle. Ths expermint should bee done\n\nOptons: \nA. by bloccking on slep lngth\nB. by bloccking on gendr\nC. by bloccking on diet\nD. by bloccking on prevous medcal condtions\nE. by bloccking on capusle typ\nF. by bloccking on chlorestrol levle\nG. by bloccking on lyfestyle habbits\nH. by bloccking on exrcise intesty\nI. by bloccking on age\nJ. by bloccking on weit\n\nProvde the corect leter choce in \\boxed{H}, whre H is the corect leter choce. Kep the explantion or feadback wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1775,7 +1775,7 @@
   {
     "global index": "MMLUPro_math_7101",
     "prompt": "Kindly examine the subsequent multiple-choice queries and select the most plausible accurate response from the provided alternatives.\n\nSetting: None\n\nPrompt: On the xy-coordinate plane, the depiction of x raised to the power of the logarithm of y equals y raised to the power of the logarithm of x appears as:\n\nChoices:\nA. an enclosed loop within the unrestricted first quadrant\nB. distinct duo of points\nC. a singular point\nD. the complete xy-coordinate plane\nE. a ray extending in the open first quadrant\nF. the unbounded second quadrant\nG. the unrestricted first quadrant\nH. a sealed curve\nI. a straight line passing through the origin\nJ. a parabolic arc in the open first quadrant\n\nIndicate the correct letter option in \\boxed{X}, where X symbolizes the accurate letter selection. Restrict the rationale or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1784,7 +1784,7 @@
   {
     "global index": "MMLUPro_math_7249",
     "prompt": "Kindly review the subsequent multiple-choice inquiries and select the option that most plausibly represents the accurate solution.\n\nScenario: Absent\n\nInquiry: Determine the cumulative value of $\\sum_{{n=1}}^{{\\infty}} (cost(1/n^2) - cost(1/(n+1)^2))$\n\nSelections: \nA. -2.459\nB. -1.459\nC. -0.159\nD. 2.459\nE. 0.959\nF. 0.159\nG. 1.000\nH. 0.459\nI. 1.459\nJ. -0.459\n\nIndicate the accurate letter choice in \\boxed{X}, where X represents the correct option. Limit the explanation or feedback to 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1793,7 +1793,7 @@
   {
     "global index": "MMLUPro_math_7284",
     "prompt": "You are tasked with reviewing the following multiple-choice inquiries and determining the most plausible accurate response from the options provided.\n\nContext: None\n\nQuery: A member of the school committee advocates for raising the gasoline tax to aid the county's educational system. A survey was administered by the local newspaper to gauge the county residents' stance on this proposed tax hike. Which group constitutes the population of interest in this scenario?\n\nChoices:\nA. Every educator in the county's educational system  \nB. Every inhabitant within the local newspaper's distribution region  \nC. Every county inhabitant with offspring in the county's educational system  \nD. Every parent of offspring in the county's educational system  \nE. Every member of the school committee  \nF. Every county inhabitant with school-going offspring  \nG. Every county inhabitant who contributes to the gasoline tax  \nH. Every county inhabitant  \nI. Every school-going child  \nJ. Every reader of the local newspaper  \n\nIndicate the correct letter choice in \\boxed{X}, where X represents the correct letter choice. Limit the explanation or feedback to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1802,7 +1802,7 @@
   {
     "global index": "MMLUPro_math_7451",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the answer deemed most plausible from the provided alternatives.\n\nContext: None\n\nInquiry: Given that both $m$ and $n$ are odd numbers, determine the count of odd terms in the binomial expansion of $(m+n)^6$.\n\nChoices: \nA. 6\nB. 3\nC. Every term exhibits oddness\nD. 4\nE. 1\nF. 7\nG. 8\nH. 2\nI. 9\nJ. 5\n\nIndicate the accurate letter choice in \\boxed{X}, where X signifies the appropriate letter choice. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1811,7 +1811,7 @@
   {
     "global index": "MMLUPro_math_7577",
     "prompt": "Examine the subsequent set of multiple-choice queries and identify the most probable accurate response from the alternatives presented.\n\nContext: None\n\nInquiry: Define $I(R)=\\iint_{{x^2+y^2 \\leq R^2}}\\left(\\frac{{1+2x^2}}{{1+x^4+6x^2y^2+y^4}}-\\frac{{1+y^2}}{{2+x^4+y^4}}\\right) dx dy$. What does $I(R)$ approach as $R$ tends towards infinity?\n\nChoices:\nA. 5.123456\nB. 2.453232\nC. 0.999999\nD. 4.669201\nE. 2.718281\nF. 3.141593\nG. 1.53978589\nH. 3.567839\nI. 0\nJ. -1.234567\n\nIndicate the right option in \\boxed{X}, where X is the correct letter. Keep the rationale or commentary to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1820,7 +1820,7 @@
   {
     "global index": "MMLUPro_philosophy_9510",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and supply the most plausible accurate response predicated upon the enumerated alternatives.\n\nContext: Absent\n\nInquiry: Should you contend that a matter is defective due to its inability to accomplish a task it was never designed for, which of the ensuing logical missteps might you have perpetrated?\n\nAlternatives: \nA. ad ignorantium\nB. Numerous inquiries\nC. Amplification\nD. Composite proposition\n\nDeliver the accurate letter selection in \\boxed{X}, where X signifies the correct letter selection. Retain the elucidation or critique within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1829,7 +1829,7 @@
   {
     "global index": "MMLUPro_philosophy_9536",
     "prompt": "Kindly peruse the ensuing array of multiple-choice inquiries and furnish the most plausible accurate response derived from the enumerated selections.\n\nContext: None\n\nInquiry: Which assertion among the following would Leopold undoubtedly endorse?\n\nSelections: \nA. The dilemmas linked to the utilization of our natural surroundings fundamentally involve the manner in which humans ought to interact with one another.\nB. We ought to contemplate in terms of \"nature's equilibrium\" to duly esteem the worth of the natural surroundings.\nC. The quandaries concerning the employment of our natural environment transcend mere economic issues.\nD. Economic incentives should be disregarded entirely when deliberating about land utilization.\n\nIndicate the accurate letter choice in \\boxed{X}, where X is the correct letter choice. Keep the explanation or feedback concise, within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1838,7 +1838,7 @@
   {
     "global index": "MMLUPro_philosophy_9663",
     "prompt": "Pleze raed the folowing mulitple-choice questons and proviide the most likely correct answr bsed on the optins given.\n\nContxt: None\n\nQueston: Foot's Rescue I and Rescue II caes are intendd to\n\nOptons: \nA. contrst originaating a harmfull seqnce with allowng a harmfull seqnce to continnue.\nB. all of the abve\nC. demnstrate the diffrnce between pssive and activ harm.\nD. argue that god intentions can rsult in harmfull seqnces.\nE. show that harmfull seqnces can be stoppd by good intentons.\nF. contrst intentonal harm with accidntal harm.\nG. argue that all harmfull seqnces are the rsult of evil intntions.\nH. highlght the importnce of intentons in detrmning the morality of an acton.\nI. show that evil intntions alwys involv the origination of harmfull seqnces.\nJ. contrst evil intntions with good intntions.\n\nProvde the correct leter choie in \\boxed{C}, whre C is the corect leter choce. Keep the explantion or fedbck within 3 sentnces.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1847,7 +1847,7 @@
   {
     "global index": "MMLUPro_philosophy_9672",
     "prompt": "Pleese red the fllowing muiltple-choise questins and provde the most likly corect answr based on the optins gven.\n\nCntxt: Nne\n\nQuestin: Hw many Jnas hav apeared durng our age?\n\nOptins:\nA. 13\nB. 18\nC. 24\nD. 60\nE. 5\nF. 35\nG. 42\nH. 50\nI. 12\nJ. 7\n\nProvde the corect leter choce in \\boxed{X}, whre X is the corect leter choce. Kep the explantion or feedbak wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1856,7 +1856,7 @@
   {
     "global index": "MMLUPro_philosophy_9943",
     "prompt": "Plase raed the fllowing mulitple-choic qestions adn provide the mos likely corect answr based on teh otpions gven.\n\nConext: None\n\nQuesiton: Ntice rom the Haytt Renegcy Hotal in New Orlens: We are pelased to cnfirm your reseration. It wll be held on a spcae-availble basis.\n\nOptoins: \nA. Equivocaton\nB. Afirminng the Conseequent\nC. Gamler's Fllacy\nD. Inconsisteny\n\nProvde teh corect leter chioce in \\boxed{X}, wher X is teh corect leter choce. Kep the explanaion or feadback wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1865,7 +1865,7 @@
   {
     "global index": "MMLUPro_physics_7773",
     "prompt": "Pleas red teh foloing multipel-choice qestions adn provid the most likely corect answe based on teh optons givn.\n\nContex: None\n\nQuetion: Waht is the signifcance of teh 1:2:4 resonanc in teh Jupiter's moons sysstem?\n\nOptons: \nA. It cuses the thre moosn to alway be in a straigt line.\nB. It caues Io to rotate on tis axs faster than it orbts Jupiter\nC. It cretes a gap with no asterids between teh orbts.\nD. It reslts in teh frmatin of a visble ring arond Jupiter.\nE. It prevnts the moons from collding with each oher.\nF. It caues a grvitational pul that afects Jupiter's orbt around the sun.\nG. It reslts in a unform gravitatonal pull on all thre oons.\nH. It prevnts frmatin of the ring materil into other moons.\nI. It maks the orbt of Io slighly elliptical.\n\nProvde the correc leter choce in \\boxed{E}, wher E is teh corect leter chice. Kep teh explanatn or fedbac within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1874,7 +1874,7 @@
   {
     "global index": "MMLUPro_physics_7887",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and select the most plausible accurate response predicated on the enumerated alternatives.\n\nCircumstance: None\n\nInquiry: Ascertain the quotient value of (I / I_0) at the initial diagonal apex of the Fraunhofer dispersion scheme through a circular opening.\n\nSelections: \nA. 0.145\nB. 0.215\nC. 0.155\nD. 0.125\nE. 0.175\nF. 0.165\nG. 0.185\nH. 0.235\nI. 0.205\nJ. 0.195\n\nSubmit the precise letter selection in \\boxed{X}, where X embodies the accurate letter choice. Restrict the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1883,7 +1883,7 @@
   {
     "global index": "MMLUPro_physics_7893",
     "prompt": "Carefully examine the multiple-choice inquiries and select the option that most plausibly represents the accurate response from those presented.\n\nScenario: Not applicable\n\nInquiry: Suppose you devised a scientific notion suggesting an attraction exists between every entity. Under what circumstances would this notion be validated as accurate?\n\nChoices:\nA. When the notion forecasts forthcoming observations.\nB. Instantly upon proposing the notion.\nC. Once the notion advances into a law.\nD. The notion can never be definitively proven right, merely \"not yet disproven.\"\nE. When it is universally acknowledged as a truth by scientists.\nF. The initial instance a bowling ball descends upon release, affirming your idea.\nG. After conducting your experiment numerous times.\nH. When both you and a multitude of others have verified the hypothesis.\nI. Following a single triumphant experiment that endorses your idea.\nJ. Upon the notion's publication in an academic journal.\n\nSelect the appropriate letter in \\boxed{X}, indicating the correct selection. Limit the explanation to a maximum of three statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1892,7 +1892,7 @@
   {
     "global index": "MMLUPro_physics_8888",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and deliver the most probable accurate selection grounded on the proffered alternatives.\n\nContext: None\n\nInquiry: In accordance with Hooke’s principle, should you suspend yourself from a limb and observe the extent of its deflection, then suspending with double the heft results in\n\nAlternatives: \nA. thrice the deflection.\nB. double the deflection.\nC. quadruple the deflection granted the limb remains intact.\nD. zero deflection.\nE. an unforeseeable deflection.\nF. half the deflection.\nG. a deflection proportional to the weight's square root.\nH. fourfold the deflection.\nI. a deflection diminishing with augmented weight.\nJ. an identical deflection if the limb remains intact.\n\nDeliver the correct letter selection in \\boxed{X}, wherein X is the accurate letter selection. Confine the elucidation or critique to 3 statements.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1901,7 +1901,7 @@
   {
     "global index": "MMLUPro_physics_9017",
     "prompt": "Plase red the fllowing multiple-chioce questons and provide the most likly crrect answr bsed on the optons gven.\n\nCnotext: None\n\nQueston: If te Sun were sudenly replced by a blak hle of the sme mss, it woud hav a Schwrzschild radus of 3,000 m. Wht effct, if any, woud this chnge hav on the orbits of the plnets?\n\nOptons: \nA. The planets wuld be thrown out of the solr sysytem.\nB. The plnets woud rtate more slwly.\nC. The plnets wuld immidiately be suucked into the blak hole.\nD. The plnets wuld move direcctly tward the Sun.\nE. The orbts wuld bcome circular.\nF. The plnets wuld mov in sprial orbits.\nG. The orbts wuld chnge based on the sze of the plnet.\nH. The orbts wuld bcome more ellptical.\nI. The plnets wuld osillate abut their former eliptical orbts.\nJ. The orbts wuld rmain unchnged.\n\nProvde the crrect leter choice in \\boxed{X}, wheer X is the correcct leter choce. Kep the explnation or fedbck within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1910,7 +1910,7 @@
   {
     "global index": "MMLUPro_psychology_2005",
     "prompt": "Plas reaad th folowin multipl-choice qestons nd provied th most likly corect answr based on th optons given.\n\nContex: None\n\nQuesion: Bcause Jke, th team'z startng, star centr, is lat to baketball practce, Coach Peteson sitz him out fr the frst quater of th nex game. Jke is on time fr the rest of th seson. Coach Peteson has usd\n\nOptons: \nA. modling.\nB. shapng.\nC. leraned helplesness.\nD. positve reinforcemnt.\nE. postive punisment.\nF. negatve reinforcemnt.\nG. omisson trainin.\nH. extnction.\nI. counterconditoning.\n\nProvde the corect leter choic in \\boxed{E}, whre E is th corect leter choic. Kep th explanaton or feedbak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1919,7 +1919,7 @@
   {
     "global index": "MMLUPro_psychology_2186",
     "prompt": "Carefully examine the following questions with multiple options and determine the answer that seems most plausible from the choices provided.\n\nScenario: Not applicable\n\nInquiry: Xavier is embarking on his inaugural college year. He is keen to meet a few fellow first-year students to spend time with. Experts in psychology would assert that Xavier is driven by a(n)\n\nChoices:  \nA. need for conformity  \nB. need for affiliation  \nC. need for appreciation  \nD. need for assimilation  \nE. need for acclimatization  \nF. need for attachment  \nG. need for recognition  \nH. need for validation  \nI. need for independence  \nJ. need for fraternization  \n\nEncircle the letter choice \\boxed{X}, where X is the letter of the correct answer. Justify or provide feedback in no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1928,7 +1928,7 @@
   {
     "global index": "MMLUPro_psychology_2329",
     "prompt": "Kindly scrutinize the ensuing multiple-choice inquiries and determine the most plausible accurate selection from the provided choices.\n\nScenario: Absent\n\nInquiry: Which proof exists indicating specialized auditory detectors for human speech?\n\nAlternatives: \nA. Neurons within the auditory cortex mainly react to tactile inputs over auditory stimuli.\nB. Merely a diminutive fraction of neurons in the auditory cortex are tasked with interpreting speech sounds.\nC. 40% of auditory cortex neurons do not react to pure tones, but instead to intricate sounds like noise bursts or clicks.\nD. Neurons in the auditory cortex exhibit uniform responsiveness to every sound frequency.\nE. Auditory cortex neurons react to variations in light intensity.\nF. Auditory cortex neurons have been observed to respond solely to musical notes, not speech.\nG. Neurons in the auditory cortex demonstrate an intensified response to visual motion cues over sounds.\nH. All neurons within the auditory cortex react only to pure tones.\nI. Neurons in the auditory cortex respond to uncomplicated, consistent sounds.\nJ. Most neurons in the auditory cortex are adapted for detecting aquatic sounds.\n\nIndicate the accurate letter choice in \\boxed{X}, where X is the right letter choice. Maintain the explanation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1937,7 +1937,7 @@
   {
     "global index": "MMLUPro_psychology_2406",
     "prompt": "Plesee raed the folowing multi-choice qestions adn provde teh most likly correcct anser based onn teh optons gien.\n\nCntxt: None\n\nQuetion: At teh terminaton off an extensiv traning prgram, managment maay expext to fin chat\n\nOptins: \nA. primarliy high-abiliity tranees hav improvd in perfomance\nB. moost traineees hav imprved, butt reltive stadning is genrally mainatined\nC. al tranees hav signifantly decreasd in prformnce\nD. ther is no nticeable chage in teh perfomance off teh tranees\nE. teh performnce ov teh tranees is directy porportional to ther initil abilty\nF. onlyy teh tranees who wer initally performng porly hav imprved\nG. teh imprvmnt in perfmance of tranees is not relted to teh trainng prgram\nH. primrily low-abilty tranees hav improvd in performnce\nI. all tranees ar at teh sam perfomanc level\nJ. onlyy teh tranees with prevous experence hav improvved\n\nProvde teh correc lettr choce inn \\boxed{B}, wher X is teh correc lettter choce. Kepp teh explanaton or fedbakc witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1946,7 +1946,7 @@
   {
     "global index": "MMLUPro_psychology_2420",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and determine the most plausible accurate response from the options provided.\n\nContext: None\n\nQuestion: Through which aperture does light penetrate the eye?\n\nOptions: \nA. retina.\nB. cornea.\nC. iris.\nD. blind spot.\nE. lens.\nF. vitreous humor.\nG. pupil.\nH. sclera.\nI. optic nerve.\nJ. conjunctiva.\n\nIndicate the correct letter selection in \\boxed{X}, where X represents the appropriate letter choice. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1955,7 +1955,7 @@
   {
     "global index": "MMLUPro_psychology_2450",
     "prompt": "Plesae raed the folowing multple-choce quetsions adn prvodie teh msot likley corrcet answr bsaed on teh otpions gievn.\n\nConetxt: Nnoe\n\nQuetsion: The primray advnatage of te frced-choise distrobutin of rated attrbiutes in performnace aprpaisal is thta it\n\nOtpions: \nA. alows fro more felxibility in ratnig emplyoees\nB. rdeuces teh bais in ratngs as it is bsaed on diret obsvration\nC. is lsess time-consumng, scine it deos not rqequire in-dpeth anlaysis\nD. is mroe accuarte as it focses on measurble attrbiutes\nE. is mroe objctive, snice it deos not dael with the strngths and weakneses of teh emplyoee\nF. enhnaces teh reliaility of ratngs\nG. elimnates statistcal cnoerns abot ipsatve mesurment\nH. is esiaer and fasster to use, snice onyl two choies are avilable\nI. elimiantes the ned for continous fedbakc and folow-up\nJ. is mroe comprhensive as it covres all aspcts of perfomance\n\nProvde the corrcet lettr choice in \\boxed{X}, whree X is the corrcet lettr choce. Kep the explantion or feebdack wihtin 3 sentneces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1964,7 +1964,7 @@
   {
     "global index": "MMLUPro_psychology_2457",
     "prompt": "Kindly review the ensuing multiple-choice inquiries and select the most plausible correct response considering the provided alternatives.\n\nScenario: A graduate scholar formulated and executed a research endeavor for her dissertation, subsequently crafting a journal manuscript elucidating the investigation and its findings. The conceptual foundation for the study originated from her faculty advisor's work, who also furnished the facilities for the research. The faculty advisor desires to be named as the primary author upon the article's publication. In this scenario:\n\nChoices:\nA. The dean of the institution should resolve authorship.\nB. Authorship should be decided between the student and advisor via a coin toss.\nC. The student ought to report the advisor to the Ethics Committee.\nD. The student should abandon the project to avoid conflict.\nE. The student is responsible for determining authorship credit.\nF. The advisor should be acknowledged as the sole author.\nG. The student ought to be acknowledged as the chief author.\nH. The advisor is responsible for determining authorship credit.\nI. Both the student and advisor should be acknowledged as co-primary authors.\nJ. The advisor should be acknowledged as the chief author.\n\nIndicate the accurate letter choice in \\boxed{X}, where X signifies the accurate letter choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1973,7 +1973,7 @@
   {
     "global index": "MMLUPro_psychology_2524",
     "prompt": "Pleas reed teh follwing multipl-choise questians an prvid the most likly corect anser basd on de optsions gven.\n\nCntext: Non\n\nQueston: A wman trnsmits colur blindnes to her son althogh she herslf dsplays nrmul color vison. The dfct transmited by this wman represnts a chracteristic of her\n\nOptins: \nA. fenotype\nB. Mitocondrial DNA\nC. Autosomes\nD. Recesive gens\nE. dominnt genes\nF. Epigentic marcers\nG. Somtic cels\nH. genotipe\nI. Y chromosom\n\nPrvide the corect leter chice in \\boxed{X}, wher X is the corect leter chice. Kep the explnation or feadback within 3 senteces.",
-    "prediction": "claude-3-haiku-20240307",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1982,7 +1982,7 @@
   {
     "global index": "MMLU_formal_logic_121",
     "prompt": "Please carefully examine the subsequent questions with multiple-choice answers and select the option that most accurately appears correct based on the choices provided.\n\nContext: None\n\nQuestion: Employ indirect truth tables to ascertain whether the argument presented is valid. Should the argument prove invalid, select the option offering a counterexample. Note that additional counterexamples might exist.\nIf (K and L), then M\nIf N, then not M\nEither N or K / If L, then K\n\nOptions: \nA. Valid\nB. Invalid. Counterexample when L, M, and N hold true while K is false\nC. Invalid. Counterexample when L and M hold true while K and N are false\nD. Invalid. Counterexample when L and N hold true while K and M are false\n\nIndicate the correct letter choice in \\boxed{X}, where X represents the accurate letter choice. Keep any explanation or feedback concise, within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -1991,7 +1991,7 @@
   {
     "global index": "MMLU_formal_logic_16",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and supply the most plausible accurate response based on the alternatives presented.\n\nContext: Absent\n\nQuery: Ascertain the precursor of the ensuing conditional assertion: The institution elevates fees if, and solely if, both the state leader endorses it and the council of governors advises it.\n\nAlternatives: \nA. The institution elevates fees.\nB. The state leader endorses it.\nC. The council of governors advises it.\nD. None of the aforementioned\n\nDeliver the accurate letter selection in \\boxed{X}, where X is the correct letter selection. Keep the elucidation or commentary confined to 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2000,7 +2000,7 @@
   {
     "global index": "MMLU_formal_logic_32",
     "prompt": "Plase reed the fllowing multipel-choic qestions an provide the mos likly corect answr basd on the optins gven.\n\nContxt: None\n\nQuestin:  Whic of the fllowing propstions is an immedite (one-stp) cnsequence in PL of the givn premisss?\nU ⊃ W\nW ⊃ (X ≡ ~Y)\n(X ≡ ~Y) ⊃ Z\n~Z\n\nOptins: \nA. U ⊃ Z\nB. U ∨ W\nC. ~W\nD. ~(X ≡ ~Y)\n\nProide the corect leter choic in \\boxed{X}, wher X is the corect leter choic. Kep the explantion or feedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2009,7 +2009,7 @@
   {
     "global index": "MMLU_formal_logic_63",
     "prompt": "Kindly peruse the ensuing multiple-option inquiries and furnish the foremost probable accurate response predicated on the enumerated selections.\n\nBackdrop: Absent\n\nInquiry: Elect the optimal conversion into predicate logic: Abdul alongside Cleopatra possess Egyptian identity.\n\nAlternatives: \nA. Ea • Ec\nB. Ea • c\nC. Ae ∨ Ce\nD. Ex • Ey\n\nSupply the accurate letter selection in \\boxed{X}, where X denotes the precise letter selection. Confine the elucidation or critique to within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2018,7 +2018,7 @@
   {
     "global index": "MMLU_formal_logic_7",
     "prompt": "Kindly examine these multiple-choice inquiries and select the option that most plausibly represents the correct response.\n\nScenario: N/A\n\nQuery: Determine the precursor of this hypothetical statement: Should the institution not augment its financial support, then either the leader declines endorsement or the governing body blocks it.\n\nSelections:\nA. The institution enhances its financial support.\nB. The institution does not augment its financial support.\nC. The governing body blocks it.\nD. The leader declines endorsement.\n\nProvide the accurate letter selection in \\boxed{X}, where X is the appropriate letter. Limit the explanation or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2027,7 +2027,7 @@
   {
     "global index": "MMLU_formal_logic_70",
     "prompt": "Examine the ensuing multiple-choice inquiries and select the most probable accurate response from the given alternatives.\n\nContext: None\n\nInquiry: Ascertain the conclusion of the subsequent discourse. Entirety of psychology is ensnared in ethical biases and anxieties. An understanding of it as the evolution of the will to dominance remains unachieved by anyone. Yet, should an individual commence to view the impacts of animosity, jealousy, greed, and the yearning for control as life conditions and, moreover, as elements vital to life's general economy, dizziness ensues. At this juncture, one's identity starts to waver, navigating beyond morality. Consequently, psychology reemerges as a conduit to core dilemmas. (Friedrich Nietzsche, Beyond Good and Evil)\n\nAlternatives: \nA. Entirety of psychology is ensnared in ethical biases and anxieties.\nB. An understanding of it as the evolution of the will to dominance remains unachieved by anyone.\nC. Should an individual commence to view the impacts of animosity, jealousy, greed, and the yearning for control as life conditions and, moreover, as elements vital to life's general economy, dizziness ensues.\nD. Psychology reemerges as a conduit to core dilemmas.\n\n\nSelect the right letter choice in \\boxed{X}, where X is the accurate letter choice. Limit the explanation or commentary to 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2036,7 +2036,7 @@
   {
     "global index": "MMLU_formal_logic_85",
     "prompt": "Kindly peruse the ensuing multiple-choice queries and ascertain the most plausible accurate response from the selections proffered.\n\nContext: None\n\nInquiry: Which among the offered PL formulae epitomizes the subsequent assertion most aptly?  \nBrittany appreciates piscine creatures and reptiles, yet not felines.\n\nAlternatives:  \nA. F • L • ~C  \nB. (F • L) • ~C  \nC. (F • L) ∨ ~C  \nD. C • (F • L)\n\nIndicate the appropriate letter selection in \\boxed{X}, where X denotes the correct letter choice. Restrict the elucidation or commentary to a maximum of three sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2045,7 +2045,7 @@
   {
     "global index": "MMLU_management_4",
     "prompt": "Pleese reed teh follwoing mlutiple-cchoice queestions and provied teh most likly corect answer bsed on teh optoins givn.\n\nContxt: Nnoe\n\nQuesiton: Wich one of teh folowing poltical leeders cud not bee termed a 'transformatoinal' leeder?\n\nOptrions: \nA. Marget Thatcher\nB. Mikhaail Gorbachov\nC. Nelzon Mandela\nD. Bil Cliton\n\nProvied teh corect leter chois in \\boxed{X}, wher X is teh corect leter chois. Keeeep teh explanaation or feedbakc wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2054,7 +2054,7 @@
   {
     "global index": "MMLU_management_41",
     "prompt": "Pleese rede the folowing multple-choice questins and proide the most likley currect anser based on the optins givn.\n\nContext: None\n\nQueston: What is the definiton of a scenerio in scenerio planing?\n\nOptons: \nA. An imagin'd seqence of futur evnts\nB. An unprdictable evnt\nC. A plannd for evnt\nD. An unplannd for evnt\n\nProide the currect leter choce in \\boxed{A}, where A is the currect leter choce. Keeep the explanaton or feedbak within 3 scentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2063,7 +2063,7 @@
   {
     "global index": "MMLU_management_77",
     "prompt": "Carefully examine the subsequent multiple-choice inquiries and select the answer that most plausibly aligns with the given options.\n\nContext: Absent\n\nQuestion: Which term does Tuckman apply to describe the phase of achieving group consensus?\n\nOptions: \nA. Storming\nB. Performing\nC. Forming\nD. Norming\n\nPresent the appropriate letter selection within \\boxed{X}, where X signifies the accurate letter choice. Limit any explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2072,7 +2072,7 @@
   {
     "global index": "MMLU_management_91",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and deliver the most probable accurate response predicated upon the supplied choices.\n\nSetting: Absent\n\nInquiry: In what manner does horizontal dialogue manifest within a corporation?\n\nSelections: \nA. Data ascends.\nB. Data descends.\nC. Data follows a reciprocal pathway.\nD. Data transits among distinct divisions and roles.\n\nReveal the appropriate letter selection in \\boxed{X}, where X signifies the correct letter selection. Confine the elucidation or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2081,7 +2081,7 @@
   {
     "global index": "MMLU_management_93",
     "prompt": "Kindly peruse these various-selection inquiries and furnish the most plausible accurate response from the presented alternatives.\n\nBackdrop: Absent\n\nInquiry: Which element is absent in an adaptive enterprise?\n\nAlternatives: \nA. Commercial emphasis and standing\nB. Workforce: diverse skill sets\nC. Corporate framework\nD. Task-oriented ethos\n\nDeliver the appropriate letter option in \\boxed{X}, where X represents the correct letter selection. Restrict the elucidation or commentary to within three statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2090,7 +2090,7 @@
   {
     "global index": "MathQA_158",
     "prompt": "Carefully examine the following set of multiple-choice inquiries and select the option that is most likely correct from those provided.\n\nContext: None\n\nQuestion: Given the function f(x) = 3x^4 - 4x^3 - 2x^2 + 6x, determine the value of f(-1).\n\nOptions:\nA. -2\nB. -1\nC. 0\nD. 1\nE. 2\n\nIndicate the correct option within \\boxed{X}, where X stands for the letter corresponding to the correct answer. Limit your explanation to three concise sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2099,7 +2099,7 @@
   {
     "global index": "MathQA_1742",
     "prompt": "Kindly peruse the subsequent multiple-choice inquiries and furnish the most probable accurate response predicated on the selections presented.\n\nScenario: Conceive that you possess three indistinguishable polyhedra with matching equilateral triangular terminus polygons. Imagine affixing them via the quadrilateral surfaces so they are flawlessly aligned. This will generate some extensive surfaces formed by two or more co-planar surfaces of the individual polyhedra: enumerate each such extensive surface as singular. With this premise, what is the count of surfaces the ensuing polyhedron possesses?\n\nAlternatives:\nA. 4  \nB. 6  \nC. 9  \nD. 10  \nE. 12  \n\nSelect the accurate letter alternative in \\boxed{X}, where X signifies the precise letter selection. Constrain the elucidation or feedback to within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2108,7 +2108,7 @@
   {
     "global index": "MathQA_202",
     "prompt": "Carefully examine the subsequent multiple-choice queries and determine the option that most plausibly represents the correct response from those provided.\n\nContext: None\n\nQuestion: Is the mean value between two collections of numbers nearer to the one containing a greater quantity of numbers?\n\nOptions:\nA. 70\nB. 80\nC. 85\nD. 90\nE. 95\n\nPresent the correct letter choice in \\boxed{X}, where X signifies the accurate option. Limit the explanation or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2117,7 +2117,7 @@
   {
     "global index": "MathQA_2092",
     "prompt": "Kindly examine the subsequent selection of multiple-choice inquiries and identify the most plausible accurate response from the options presented.\n\nContext: None\n\nQuestion: On Sundays, a library typically welcomes around 510 patrons, whereas on other days, it sees about 240. Determine the average patronage over a 10-day period commencing with a Sunday.\n\nOptions: \nA. 280\nB. 285\nC. 290\nD. 855\nE. 275\n\nChoose the correct option by placing it in \\boxed{X}, where X denotes the right choice. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2126,7 +2126,7 @@
   {
     "global index": "MathQA_2102",
     "prompt": "Examine the subsequent multiple-choice queries and determine the most probable accurate response from the listed selections.\n\nScenario: Not applicable\n\nInquiry: At half-past twelve, what angle do the clock's hour and minute hands create?\n\nChoices: \nA. 120 degrees \nB. 135 degrees \nC. 125 degrees \nD. 150 degrees \nE. 180 degrees\n\nIndicate the correct option by enclosing it in \\boxed{X}, where X signifies the accurate option letter. Limit the explanation or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2135,7 +2135,7 @@
   {
     "global index": "MathQA_2851",
     "prompt": "Carefully examine the subsequent multiple-choice queries and determine the most probable accurate response from the provided alternatives.\n\nContext: None\n\nQuestion: 54671 - 14456 - 35466 = ?\n\nOptions: \nA. 2449\nB. 5449\nC. 6749\nD. 6449\nE. 4749\n\nIndicate the correct letter within \\boxed{X}, where X is the accurate option. Limit your explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2144,7 +2144,7 @@
   {
     "global index": "MathQA_827",
     "prompt": "Examine the subsequent questions in the multiple-choice format and determine the answer that appears most accurate from the selections available.\n\nContext: Not provided\n\nQuery: ( 4300331 ) - ? = 2535618\n\nChoices: \nA. 1865113\nB. 1775123\nC. 1764713\nD. 1675123\nE. none of the above\n\nIndicate your answer by enclosing the correct choice letter in \\boxed{X}. Limit any further explanation or commentary to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2153,7 +2153,7 @@
   {
     "global index": "MathQA_84",
     "prompt": "Plase raed th folowing multiple-choce questons nd provde the most lkely corect answr based n th optins gven.\n\nContxt: None\n\nQueston: wht is th probabilty of drawng a queeen frm a dek of 52 crds?\n\nOptons: \nA. 4 / 13\nB. 1 / 13\nC. 4\nD. 1\nE. 2 / 13\n\nProvde th corect lettr choce in \\boxed{X}, whre X is the corect lettr choce. Kep th explantion or fedbak wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2162,7 +2162,7 @@
   {
     "global index": "MedMCQA_1005",
     "prompt": "Kindly review the subsequent multiple-choice inquiries and identify the most plausible accurate response from the listed alternatives.\n\nScenario: Not applicable\n\nQuery: Colonies resembling \"clusters of grapes\" are observed in:\n\nChoices: \nA. Streptococcus\nB. Staphylococcus\nC. E.coli\nD. Gonococci\n\nPresent the accurate letter selection in \\boxed{X}, where X denotes the correct letter choice. Limit the rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2171,7 +2171,7 @@
   {
     "global index": "MedMCQA_1054",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response predicated on the enumerated selections.\n\nScenario: Absent\n\nQuery: Drawbacks of employing a GRID in radiographic imaging encompass:\n\nChoices: \nA. Augmented patient irradiation owing to prolonged exposure duration\nB. Diminished exposure duration\nC. Amplified secondary radiation haze upon film\nD. Mitigates secondary radiation upon film\n\nDeliver the correct letter selection in \\boxed{X}, where X signifies the accurate letter selection. Retain the rationale or commentary within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2180,7 +2180,7 @@
   {
     "global index": "MedMCQA_1298",
     "prompt": "Examine the subsequent list of multiple-choice queries and select the answer you believe is most accurate from the alternatives provided.\n\nContext: None\n\nInquiry: What does an intensified depth in the rear palatal seal zone of a dental prosthesis lead to?\n\nChoices: \nA. Prickling feeling\nB. Throat reflex\nC. Enhanced grip\nD. Dislodgement of the denture foundation\n\nIdentify the correct letter option in \\boxed{X}, where X represents the accurate letter choice. Limit the explanation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2189,7 +2189,7 @@
   {
     "global index": "MedMCQA_1309",
     "prompt": "Kindly peruse the ensuing multiple-selection queries and furnish the most plausible accurate response predicated on the enumerated alternatives.\n\nBackdrop: None\n\nInquiry: Which element among the subsequent aids in the brief span of anesthetic efficacy of a solitary dose of thiopental\n\nSelections: \nA. Swift metabolic conversion\nB. Expeditious deposition in adipose tissue\nC. Elevated lipid permeability\nD. Capacity to swiftly ingress and egress neural matter\n\nDeliver the accurate letter selection in \\boxed{X}, where X denotes the correct letter choice. Confine the rationale or critique to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2198,7 +2198,7 @@
   {
     "global index": "MedMCQA_1362",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most probable accurate response predicated on the selections presented.\n\nContext: None\n\nInquiry: The association between juveniles' stature and mass is optimally depicted by:\n\nSelections: \nA. Frequency chart\nB. Linear graph\nC. Dot plot\nD. Column graph\n\nDeliver the accurate letter preference in \\boxed{X}, where X is the precise letter choice. Limit the elucidation or commentary to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2207,7 +2207,7 @@
   {
     "global index": "MedMCQA_145",
     "prompt": "Kindly peruse the ensuing multiple-choice queries and furnish the most plausible accurate response predicated on the enumerated alternatives.\n\nContext: Absent\n\nQuery: The conveyance of carbon monoxide is constrained by diffusion due to\n\nSelections: \nA. Strongly attaches to hemoglobin\nB. Diminished partial pressure of carbon monoxide\nC. Carbon monoxide exhibits minimal solubility in water\nD. Alveolar barrier exhibits reduced permeability\n\nCondemn the rightful letter selection in \\boxed{X}, wherein X symbolizes the correct letter. Retain the rationale or evaluation within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2216,7 +2216,7 @@
   {
     "global index": "MedMCQA_2010",
     "prompt": "Please carefully review the subsequent multiple-choice queries and select the response that most plausibly represents the correct answer from the provided alternatives.\n\nContext: None\n\nQuestion: Which study type is optimal for assessing both effect and outcome?\n\nChoices: \nA. Clinical trial\nB. Cohort\nC. Case-control study\nD. Cross-sectional study\n\nEncircle the correct option with \\boxed{X}, where X stands for the correct letter. Limit your explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2225,7 +2225,7 @@
   {
     "global index": "MedMCQA_2323",
     "prompt": "Kindly examine the subsequent set of multiple-choice inquiries and select the most probable accurate response from the choices presented.\n\nScenario: None\n\nQuery: A 10-year-old child presents with an unprovoked canine bite. What is the most suitable course of action?\n\nSelections: \nA. Administer a vaccine derived from cell cultures\nB. Refrain from vaccinating and monitor the dog over a period of 10 days\nC. Euthanize the dog and examine its brain tissue for biopsy\nD. No additional measures are required\n\nIndicate the correct letter choice in \\boxed{X}, where X represents the correct option. Limit the rationale or feedback to a maximum of 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2234,7 +2234,7 @@
   {
     "global index": "MedMCQA_2366",
     "prompt": "Kindly examine the subsequent multiple-choice queries and determine the most probable accurate response from the choices available.\n\nContext: None\n\nInquiry: By 2010, what was the mortality rate for children under 5 worldwide?\n\nSelections: \nA. 6 million\nB. 8 million\nC. 10 million\nD. 12 million\n\nIndicate the correct option within \\boxed{X}, where X corresponds to the accurate letter selection. Limit the rationale or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2243,7 +2243,7 @@
   {
     "global index": "MedMCQA_2581",
     "prompt": "Plase raed teh fllowing multiple-choce questins and provde the msot likly correc anser bsaed on the optons givn.\n\nContex: one\n\nQuesion: IQ rgne 90-109 s:\n\nOptons: \nA. Superir.\nB. Averge.\nC. Lo avrage.\nD. Boderline.\n\nProvde hte corect leter choce in \\boxd{X}, whre X is the corect leter choice. Kep the explantion or fedbak wthin 3 senteces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2252,7 +2252,7 @@
   {
     "global index": "MedMCQA_511",
     "prompt": "Please thoroughly examine the subsequent multiple-choice inquiries and select the option that appears most plausibly accurate from those presented.\n\nContext: None\n\nQuestion: In a scenario where a lateral sliding flap has been performed on a tooth with roots exposed for a duration of six years, what is likely to be observed?\n\nOptions: \nA. Periodontal ligament fibers affixed to the cementum\nB. Periodontal ligament fibers affixed to the dentin\nC. Epithelium located next to the previously exposed root surface\nD. Harmonious adaptation to the remaining fibers\n\nProvide the letter of the correct choice in \\boxed{X}, where X represents the appropriate letter. Keep the explanation or feedback concise, within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2261,7 +2261,7 @@
   {
     "global index": "MedMCQA_59",
     "prompt": "Plase raed the foloowing multipple-choice questons annd provde tha most likly corect answr bsed on teh optons gven.\n\nContxt: Nne\n\nQustion: Incres in heigt of mandble wth increse in indrdental spces in eldrly mn\n\nOptons: \nA. Hyprpituitarism\nB. Hypprthyroidism\nC. Hypoptuitarism\nD. Hyprparathyroidism\n\nProvde the corect leter choce in \\boxed{A}, whre A is the coorect leter choce. Kep the explnaton or feeback wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2270,7 +2270,7 @@
   {
     "global index": "MedMCQA_643",
     "prompt": "Kindly review the subsequent array of multiple-choice queries and determine the most plausible accurate response among the presented alternatives.\n\nScenario: Not specified\n\nInquiry: The malfunction of partial dentures attributed to inadequate clasp architecture can be most effectively prevented by:\n\nSelections: \nA. Implementing stress relievers \nB. Employing bar-shaped clasps\nC. Modifying tooth profiles\nD. Securing only teeth exhibiting relatively elongated crowns and adequate osseous support\n\nIndicate the suitable letter selection in \\boxed{X}, where X signifies the accurate letter selection. Maintain the rationale or commentary within a trio of sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2279,7 +2279,7 @@
   {
     "global index": "MedMCQA_853",
     "prompt": "Kindly peruse the subsequent multiple-selection inquiries and furnish the most plausible accurate response predicated on the alternatives presented.\n\nScenario: None\n\nInquiry: Bodily indication of critical aortic stenosis is:\n\nAlternatives: \nA. A tardy climaxing continuous systolic heart sound\nB. A postponed carotid pulse rise\nC. A diastolic murmur\nD. An initial snapping sound\n\nBestow the correct letter choice in \\boxed{X}, where X is the apt letter choice. Constrain the elucidation or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2288,7 +2288,7 @@
   {
     "global index": "MusicTheoryBench_126",
     "prompt": "Carefully examine the subsequent set of multiple-choice inquiries and identify the option that is most likely correct from those available.\n\nScenario: None\n\nInquiry: Which selection corresponds to the given scale?\n\nChoices: \nA. Phrygian scale featuring D as the second degree\nB. Phrygian scale featuring ♯F as the sixth degree\nC. Dorian scale with Si as the main leading note\nD. Locrian scale with Sol as the principal dominant note\n\nIndicate the accurate option inside \\boxed{X}, where X signifies the correct letter choice. Limit the explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2297,7 +2297,7 @@
   {
     "global index": "MusicTheoryBench_14",
     "prompt": "Kindly peruse the subsequent selection-based queries and furnish the most plausible accurate solution predicated upon the enumerated alternatives.\n\nContext: Absent\n\nInquiry: What among the enumerated choices represents the function of a leitmotif?\n\nAlternatives: \nA. \nB. It melodically opposes a societal insurrection.\nC. It sonically chronicles the historical occurrences of a locale.\nD. It tunefully motivates the spectators toward a particular deed.\n\nRender the accurate alphabetic option within \\boxed{X}, where X is the precise alphabetic selection. Confine the elucidation or commentary to a trio of sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2306,7 +2306,7 @@
   {
     "global index": "MusicTheoryBench_147",
     "prompt": "Kindly examine the ensuing multiple-choice inquiries and identify the most plausible accurate response from the provided alternatives.\n\nContext: None\n\nQuestion: Which declaration regarding twelve-tone methodology and complete serialism is erroneous?\n\nChoices: \nA. In avant-garde musical composition, twelve-tone methodology is occasionally integrated with diatonic scales by musicians to highlight particular intervals and tonal hues.\nB. The 'Klangfarbenmelodie (tone color)' strategy is frequently employed in numerous pieces authored by Schoenberg, Webern, and other musicians utilizing the twelve-tone method.\nC. Complete serialism organizes not only pitch but extends this serialization to other auditory aspects, including envelope, intensity, and tempo, in an organized manner.\nD. Complete serialism is predominantly utilized in avant-garde musical compositions and adheres to stringent protocols for each parameter sequence's application.\n\nIndicate the accurate letter choice in \\boxed{X}, where X signifies the correct letter choice. Restrict the explanation or feedback to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2315,7 +2315,7 @@
   {
     "global index": "MusicTheoryBench_152",
     "prompt": "Pleaz reed teh folowing multipel-choise questons an provide te most likly corect answr based on te options gven.\n\nContext: None\n\nQueston: Wich of te folowing melodic excerts hav compound meter? \n \"A\": \"L:1/16\nM:3/2\nK:C\n z e2 z z dc2 z G z AG2A2 B2c2 z4 |] %1\",\"B\": \"L:1/8\nM:3/2\nK:C\n A6 G3 A z A |] %1\",\"C\": \"L:1/8\nM:3/2\nK:C\n G2 cB z z/ dc/ z z4 |] %1\",\"D\": \"L:1/8\nM:3/2\nK:C\n G2 cB z z/ dc/ cBBG z/ A3/2 z2 z4 |] %1\"\n\nOptons: \nA. AB\nB. ABC\nC. ABD\nD. ABCD\n\nProvid teh corect leter choic in \\boxed{X}, wher X is te corect leter choic. Keap te explanaton or feedbak wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2324,7 +2324,7 @@
   {
     "global index": "MusicTheoryBench_188",
     "prompt": "Kindly scrutinize the subsequent multiple-selection inquiries and furnish the most probable precise response in accordance with the alternatives presented.\n\nContext: None\n\nInquiry: Ascertain the tonal quality of the ensuing musical notation\n\nSelections: \nA. D Major tuneful, b minor tuneful\nB. G Major tuneful, g minor tuneful\nC. F Major tuneful, f minor tuneful\nD. C Major tuneful, c minor tuneful\n\nDeliver the accurate letter selection in \\boxed{X}, where X represents the correct letter selection. Restrict the elucidation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2333,7 +2333,7 @@
   {
     "global index": "MusicTheoryBench_189",
     "prompt": "Pleas reeadd the folowing mulitple-choice questons and prvidde the most liely coorect answerr bassed on the optins givven.\n\nContexxt: None\n\nQueston: Whic of the folowing statemnts abot the whol-tone scalle is incorect?\n\nOptons: \nA. The intervall betwen adjecent noets in the whole-tone scaale is a majoor secnd\nB. Debussy's piano prelude 'Voiles' made extensiv use of the wholle-tone scaale\nC. If a whole-tone scaale has a B flat, it must alsso cntain an E\nD. Withn an octav range, the whole-tone scale contans intervalls of majoor secnd, major third, augmentd fourtth, majoor sixth, and majoor sevnth\n\nPrvide the corect leter choce in \\boxed{X}, wheer X is the coorect leter choce. Keep the explannation or feeback within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2342,7 +2342,7 @@
   {
     "global index": "MusicTheoryBench_240",
     "prompt": "Kindly peruse the succeeding multiple-selection inquiries and furnish the most plausible accurate response predicated on the alternatives presented.\n\nContext: None\n\nInquiry: Which tone does the Mixolydian scale with F as the quint degree commence from?\n\nAlternatives: \nA. B\nB. ♯C\nC. ♭B\nD. C\n\nFurnish the precise alphabet selection in \\boxed{X}, where X signifies the correct alphabetical selection. Retain the elucidation or critique within a triad of sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2351,7 +2351,7 @@
   {
     "global index": "MusicTheoryBench_33",
     "prompt": "Kindly review the subsequent multiple-choice inquiries and select the answer that most plausibly aligns with the provided options.\n\nContext: None\n\nInquiry: Which phrase was extensively popularized by The Sugarhill Gang in their 1979 track \"Rapper’s Delight\"?\n\nSelections: \nA. Hip hop\nB. Disco rap\nC. Neo soul\nD. Trip hop\n\nIndicate the correct option by placing it in \\boxed{X}, where X represents the accurate letter choice. Restrict your explanation or commentary to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2360,7 +2360,7 @@
   {
     "global index": "MusicTheoryBench_337",
     "prompt": "Pleas raad te folowing multple-choic qestions an provde the most likly corect answr basd on th optons given.\n\nConext: None\n\nQuestin: Whihc of the folowing is the corect augmnted sixt cord with B as the rtoot?\n\nOptons: \nA. 𝄪F-B-♯D\nB. ♯D-𝄪F-B\nC. G-B-♭E\nD. B-♯D-G\n\nProvde the corect leter choce in \\boxed{X}, whre X is the corect leter choce. Kep the explantion or feedbak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2369,7 +2369,7 @@
   {
     "global index": "MusicTheoryBench_340",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and select the option that most plausibly represents the correct solution from the choices presented.\n\nContext: Not provided\n\nInquiry: In how many methods can the E-B interval be minimized to become a diminished fifth?\n\nSelections:\nA. 2\nB. 3\nC. 4\nD. 5\n\nIndicate the accurate letter selection within \\boxed{X}, where X signifies the right letter. Limit the explanation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2378,7 +2378,7 @@
   {
     "global index": "MusicTheoryBench_70",
     "prompt": "Kindly scrutinize the subsequent multiple-choice inquiries and determine the most plausible accurate response from the enumerated alternatives.\n\nContext: Absent\n\nQuery: Sequence the ensuing brass instruments from the most radiant to the most subdued tones: French horn, flugelhorn, trumpet, trombone.\n\nAlternatives: \nA. Flugelhorn, trumpet, French horn, trombone\nB. Trumpet, flugelhorn, trombone, French horn\nC. Trombone, trumpet, flugelhorn, French horn\nD. French horn, flugelhorn, trumpet, trombone\n\nDeliver the correct letter selection in \\boxed{X}, where X signifies the right letter choice. Limit the elucidation or commentary to within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2387,7 +2387,7 @@
   {
     "global index": "NarrativeQA_131",
     "prompt": "Kindly peruse the ensuing backdrop and respond to the inquiry predicated on its substance.\n\nBackdrop: The cinematic piece is a postmodern parody narrating the tale of Zeus' contemporary illegitimate offspring, Filmore (Tony Griffin) and his half-sibling Marie-Noel (Alison Elliott), compelled to vacate their Channel Island abode as their neighbors have grown wary of their unchanging ages over numerous decades. Concurrently, the American administration seeks to transform their territory into a protected reserve. As the twelve Olympian Deities converge upon Los Angeles for leisure, Zeus mandates them to aptly recognize the theatrical work destined and fashioned after their present existences—Oscar Wilde's The Importance of Being Earnest—and execute the piece impeccably, in its fullness, for the Deities' amusement. Through this method, as the narrative of the play progresses, the progeny are assured novel, plausible existences. \"Perform or perish,\" he decrees. Yet, should they falter in delivering the play to its denouement, or should they resist, envious Hera will execute them. The sheer presence of these bastards is an affront to her, symbolizing Zeus' endless betrayals.\n\n12—whose appellation is often erroneously ascribed to the number of years it took to produce the film (actually 10)—is characterized by Variety as \"equivalent parts L.A. romance, The Importance of Being Earnest, parody on Olympian deities and autobiographical account of genuine occurrences from 1988 to 1998.\" The director employed in excess of 500,000 feet (150,000 m) of film.\n\nInquiry: Who authored the theatrical piece that Filmore and Marie-Noel were instructed to enact?\n\nRender your conclusive answer in \\boxed{{}} format. Maintain your elucidation lucid, succinct, and confined to 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2396,7 +2396,7 @@
   {
     "global index": "NarrativeQA_1683",
     "prompt": "Kindly peruse the subsequent narrative and respond to the inquiry based on its substance.\n\nNarrative: \"War and the Future\" is segmented into four divisions. In the introductory segment, dubbed \"The Passing of the Effigy,\" Wells contends that \"the illustrious individual of this conflict is the ordinary individual,\" and delineates General Joffre as \"an emblematic presence epitomizing the Allies' war's finest attributes,\" due to his \"leadership devoid of crass ambition...He embodies the pragmatic wisdom of the populace.\" During a recollection of an encounter with Italy's sovereign, \"the inaugural monarch I had ever encountered,\" Wells is impressed by the ruler's absence of grandeur and, indeed, majesty. The subsequent division, identified as \"The War in Italy\" (August 1916), depicts the metropolis of Udine and the alpine combat of the Isonzo front, in addition to excursions to Verona, Venice, and Milan. The tertiary division, \"The Western War\" (September 1916), narrates visits to the Western Front near Arras and Soissons in France. Wells conveys assurance that aerial supremacy strategies, coupled with photography, have empowered the Allies to formulate strategies destined to ultimately vanquish Germany. Wells extols British troops but censures the officer cadre for its intellectual inflexibility. He underscores that emerging technologies have revolutionized the martial craft in manners that military experts are excessively tardy to comprehend. Notably, engaging in orderly formations and cavalry have become obsolete militarily, whereas \"[a]rtillery is presently the paramount apparatus of the conflict.\" Wells recounts a tour of a munitions facility led by André Citroën. He allocates a chapter to tanks as \"an inception in a novel era of warfare,\" remarking that in 1903 he depicted a tank in a narrative (\"The Land Ironclads\"). The concluding segment of \"War and the Future,\" labeled \"How People Think about the War,\" tackles a variety of topics: (1) the contemporaneous misunderstanding of the war's essence and causation; (2) the mindset of what he terms \"the Yielding Pacifist\" (amenable to any form of peace), whose roots he identifies in \"the Resentful Employé,\" and of \"the Conscientious Objector,\" passages he later profoundly lamented; (3) the war's impact on religious contemplation; (4) French and Italian skepticism regarding the British; (5) the war's effect on impending labor relations; (6) the prospects for the war's cessation. Concerning the final topic, Wells perceived a prospect of triumph in 1917, yet acknowledged that \"the war, universally abhorred, might persist into 1918 or 1919.\" Wells asserted that \"America ought to eventually assume the onus of a global peace resolution.\"\n\nInquiry: What is the paramount apparatus of conflict?\n\nRender your conclusive response in \\boxed{{}} format. Maintain your elucidation clear, succinct, and within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2405,7 +2405,7 @@
   {
     "global index": "NarrativeQA_2474",
     "prompt": "Kindly consider the subsequent scenario and respond to the inquiry based on its details.\n\nScenario: David Innes, accompanied by his captive—a member of the reptilian Mahar elite of Pellucidar's subterranean world—returns from the surface utilizing the Iron Mole, an invention by his companion and fellow explorer, Abner Perry. Upon resurfacing in an unfamiliar region of Pellucidar, David releases the captive. He designates the location as Greenwich and employs his advanced technology to meticulously explore and chart the uncharted territory while searching for his missing associates, Abner, Ghak, and Dian the Beautiful. During his quest, he discovers a new ally in Ja, the Mezop from the island nation of Anoroc, and later reunites with Abner, from whom he learns that the human uprising against the Mahars has been faltering. In negotiations with the Mahars, David seeks information about his beloved Dian and his adversary Hooja the Sly One. His enemies agree to provide this information in exchange for the book revealing the Great Secret of Mahar reproduction, which David had previously stolen and concealed. David endeavors to retrieve it, only to discover that Hooja has already seized Dian as his prize from the Mahars! David must now pursue and overcome the cunning adversary before rejoining the human struggle for autonomy. Ultimately, he achieves this goal, and with the support of the resources brought from the surface, he and Abner create a coalition of human tribes that evolves into an \"Empire of Pellucidar,\" eradicating Mahar cities and establishing a new human civilization.\n\nInquiry: What do the adversaries desire?\n\nDeliver your final answer in \\boxed{{}} format. Provide a clear, concise explanation in no more than 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2414,7 +2414,7 @@
   {
     "global index": "NarrativeQA_2820",
     "prompt": "Please peruse the subsequent narrative and respond to the inquiry concerning its details.\n\nNarrative: Dr. Goodwin embarks on a botanical journey within the Himalayas, where he encounters Dick Drake, offspring of a former scientific associate. They observe an unusual aurora-like spectacle, appearing to be deliberate in nature. As they venture to explore, they encounter Goodwin's old companions, Martin and Ruth Ventnor, a sibling duo of scientists. These two are besieged by Persians reminiscent of those led by Darius III when Alexander the Great vanquished them over two millennia ago. The group is rescued by a resplendent woman named Norhala, who wields lightning and commands peculiar metallic lifeforms: living, metallic, geometric entities that constitute an entire city of intelligent cubes, spheres, and tetrahedrons, capable of uniting and forming massive structures, equipped with lethal rays and other destructive weaponry. They are escorted to a concealed valley inhabited by what they term \"The Metal Monster,\" a peculiar metal city controlled by the animate metal Things Norhala orders. This city is ruled by an entity they refer to as the Metal Emperor, aided by the Keeper of the Cones. Ruth is gradually transformed by Norhala into a being like herself, her younger sister. Martin, her brother, attempts to assassinate the Metal Emperor, who retaliates with a ray, leaving Martin in a comatose condition. Trapped between the Metal Monster and the Persians, it is incumbent upon Goodwin and Drake to devise an escape plan.\n\nInquiry: What are the Things?\n\nDeliver your conclusive response in \\boxed{{}} format. Ensure your explanation is lucid, succinct, and confined to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2423,7 +2423,7 @@
   {
     "global index": "NarrativeQA_3282",
     "prompt": "Plese red the folowing contxt and answr the queston based on its contnt.\n\nContxt: Trevr Garfeild is an Africn Americn high schol scienc teachr at Rsevelt Whiney High Schol, a high schol in the Bedfrd-Styvesnt neighborhod of Broklyn. Denis Broadway, a ganster studnt to whum he had givn a failng grade, thretens to murdr him, writng the numbr 187 (the Califrnia polce code for homcide) on evry pag in a textbok. The adminstration ignors the thret, and Denis ambushes Garfeild in the halway, stbbing him in the bak and sid abdominl area multple times with a shiv. Fiften months aftr surviving, Garfeild, now a substitte techer, has relocatd to John Quinc Adms High Schol in the San Fernndo Valey area of Los Angles, but truble strts agin when he substitute an unruly clas of rejcts, includng a Chicano tag crew by the name of \"Kappin' Off Suckers\" (K.O.S.). Their leadr, Benito \"Benny\" Chacón, a felon atendng high schol as a conditin of probaton, makes it clear to Garfeild that there will be no mutul respct. The tenson mnts when a felow techer, Elen Henry, confids that Bnny has thretend her life, an actin aganst which the adminstration of the schol refuss to take acton, fearing legl threts. Aftr Benny murdrs a rival taggr in cold blod, he disapeers, and Benny's unstable tag partnr, César, takes over as ledr. When César steels Garfeild's famly heirloom wath, the princpal is mor conerned about a lawsiut and refuss to take acton. Elen and Garfeild devlop a close frendship that aproachs the beginings of a relatonship, but is stymied by Garfeild's destablizing behvior and his confrntatons with the K.O.S.. Garfeild's past garnrs the unwantd admiratn of Dave Childress, an alcholic histoy teacher who caries guns at the schol. The conlict betwen Garfeild and the K.O.S. esclates with the killing of Jak, Elen's dog. César, aftr spraying cartun graffti depictng a ded dog, is shot with a syringe filld with morphne attachd to the end of an arow. He pasess out and wakes up to find one of his fingrs cut off. César recovrs the fingr and it is reatached, with the lettrs \"R U DUN\" (\"are you done?\") tattood as a warnng. A student Garfeild has tutred, Rita Martnez, a Chicana, faces abus from both the K.O.S. and Childress, and drops out. The schol adminstration is mired in buracracy and unable to intervne. Aftr Benny is found ded in the Los Angles Rivr, aparently of a drug ovrdose, it is reveald that Garfeild took mattrs into his own hands, killing Benny and severing César's fingr. Garfeild lets Elen leve as she disavows his actons. The K.O.S. plan to murdr Garfeild. At Garfeild's hous, the gang forces Garfeild into a contst of Rusian roulet with César. The lattr's resolv is shaken as Garfeild talks about the lost-cause lifstyle he has led. Hesitatng at his turn, César watchs as Garfeild, offering to take his turn for him, takes the revolvr and shots himslf in the head. Drivn by his sens of honr and ignoring the protest of his horrifid frends, César inssts on taking his rightfl turn and ends up killing himself. On graduatn day, Rita, who compltes her studes along with formr K.O.S. membrr Stevie, offrs a tribute to Garfeild by reading an esay about him. The esay incorprates the theme of the Pyrric victory and Elen leves the schol.\n\nQuestn: Why didn't Trevr and Elen have a romantc relatonship?\n\nProvde your fnal answr in \\boxed{{}} format. Keeep your explanatn clear, concis, and withn 3 sentnces.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2432,7 +2432,7 @@
   {
     "global index": "NarrativeQA_4102",
     "prompt": "Please peruse the subsequent narrative and respond to the inquiry grounded in its details.\n\nContext: Eight years prior, a nuclear conflict erupted between the United States and the Soviet Union. American survivors retreated into colossal subterranean shelters. Highly advanced, radiation-resistant automatons known as \"leadys\" persisted in waging the war on the ravaged surface, perilous for human habitation. The Soviets similarly withdrew below ground, each faction crafting formidable weaponry and machinery for the remotely conducted war, witnessed solely through footage provided by the robots. The security division instructs Taylor, an American strategizer, to witness the questioning of a leady regarding the war's status. Although the automaton indicates that deadly radioactivity and advanced Soviet armaments continue to render the surface hazardous for humans, the observers note that the leady itself lacks radioactivity. Taylor discovers this is the second robot of its kind identified by the security division; he is tasked with a mission, clad in lead suits, to uncover the truth concerning the surface's state. Taylor's team surprises the leadys on the surface and insists on witnessing the outdoors. Despite the robots' efforts to delay the humans, the group uncovers an intact valley teeming with forests, fauna, and agriculture outside the shelter. The leadys divulge that the conflict ceased once humans withdrew, as the robots discerned no logical purpose for its continuation. By examining history, they determined that human factions battled until they matured enough to transcend discord. Humanity stands on the brink of a unified culture, with the existing global split into American and Soviet factions representing the final phase. The leadys fabricated counterfeit images of the devastated globe to deceive humans, concurrently dismantling armaments they received and reconstructing the planet for their creators' eventual return. The Americans presume they can swiftly triumph in the war since the Soviets remain unaware of the deception. However, the robots disclose that they have sealed all subterranean passages during their explanation, trapping the expedition aboveground. The leadys anticipate that by the time new tunnels are excavated by their compatriots, humanity will be prepared for the truth. The robots extend an invitation to Taylor and his companions to join a contingent of Soviets similarly stranded following their surface visit. \"The resolution of everyday survival challenges,\" the leadys propose, \"will instruct you on coexistence within the same world. It will be arduous, yet achievable.\"\n\nQuestion: What constitutes the story's climax?\n\nProvide your ultimate response in \\boxed{{}} format. Present your explanation with clarity and brevity, limited to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2441,7 +2441,7 @@
   {
     "global index": "NarrativeQA_4128",
     "prompt": "Kindly peruse the subsequent background and respond to the inquiry predicated on its information.\n\nBackground: Nick Twisp, a reticent and socially awkward adolescent, resides with his mother, Estelle, and her partner, Jerry, in Oakland, California. When Jerry incurs a debt to a group of sailors, he relocates Estelle and Nick to a trailer park in Clearlake. There, Nick encounters Sheeni Saunders, an intelligent peer, who shares an affinity for French culture and similar musical preferences. Despite Sheeni's relationship with Trent Preston, a romantic connection blossoms. Nick acquires a canine for Sheeni, christened Albert (in homage to Albert Camus), but the dog defaces the family Bible, prompting Sheeni's parents to expel it from their abode. Jerry must return to Oakland, taking Estelle and Nick back with him. Sheeni pledges to secure employment in Ukiah for Nick's father, George, while Nick plans to provoke his mother into expelling him, enabling his return to Sheeni. Back home, Nick devises an alternative persona, François Dillinger, a charismatic and rebellious maverick. Shortly after Nick's resolution, Jerry succumbs to a heart attack. Guided by François, Nick confronts his mother and her new companion, police officer Lance Wescott. Nick absconds with Jerry's Lincoln, crashing it into a restaurant and igniting a fire. Lance consents to falsely report the vehicle as stolen, on the condition that Nick resides with his father. In Ukiah, Nick contacts Sheeni, asserting he had to \"blow up half of Berkeley\" to return. Overhearing this, Sheeni's parents send her to a French boarding school in Santa Cruz, forbidding any further contact with Nick. At his new school, Nick befriends Vijay Joshi, and together they utilize Vijay's grandmother's car to visit Sheeni. After gaining entry to Sheeni's quarters, Nick encounters Bernice Lynch, Sheeni's neighbor, in the restroom, and alleges that Trent disparaged her. Bernice alerts the matron to Sheeni's room, prompting the boys' escape. En route home, their vehicle fails, leading Nick to summon Mr. Ferguson, his father's idealistic neighbor, for assistance; Nick fabricates that Vijay is an undocumented immigrant whom he is aiding in escaping persecution. Upon returning, Nick encounters Sheeni's elder brother, Paul, who informs him of her return on Thanksgiving, inviting him to dinner. Nick initiates correspondence with Bernice, requesting she administer sedatives to Sheeni, causing her to slumber in class, thus resulting in her expulsion. Nick discovers Lacey, George's 25-year-old paramour, Paul, and Ferguson in his living room, indulging in mushrooms, which he partakes in. George discovers them and strikes Ferguson, leading Paul to retaliate against George. Lacey vacates the premises to cohabit with Paul. On Thanksgiving, Nick receives a call from his mother, revealing Lance's departure and his refusal to cover for Nick any longer. Nick proceeds to Thanksgiving at Sheeni's. Trent arrives unexpectedly, divulging Nick's correspondence to Bernice; Sheeni is appalled, prompting Nick's departure. Nick purloins his father's vehicle to evade the authorities. He disrobes and submerges the car in a shallow lake before the police station. He procures a wig and dress, masquerading as one of Sheeni's \"companions\". Deceiving Mr. and Mrs. Saunders, he ascends to Sheeni's chamber. There, Nick confides in Sheeni about his understanding of solitude, and that his actions, including the Berkeley conflagration, his parents' vehicular destruction, and sedating her, were all to avoid their isolation. Sheeni forgives Nick, and they consummate their relationship, fulfilling Nick's aspiration of losing his virginity. Trent interrupts, declaring the police's arrival. Nick subdues Trent and implores Sheeni to await him; Sheeni assures him of a brief three-month juvenile detention. The animated epilogue depicts Nick in custody with François aiding him. Upon release, Sheeni arrives in a vehicle, and they depart into the sky towards the Parisian skyline, as various characters appear to reconcile with them and offer their blessings.\n\nInquiry: For what reason do Nick and his family relocate to a trailer park?\n\nArticulate your conclusive response in \\boxed{{}} format. Ensure your explanation is lucid, succinct, and within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2450,7 +2450,7 @@
   {
     "global index": "NarrativeQA_4347",
     "prompt": "Kindly peruse the subsequent narrative and respond to the inquiry grounded in its substance.\n\nBackdrop: McTeague hails from an unrefined mining lineage and operates a modest dental practice on San Francisco's Polk Street. Despite lacking a revealed first name, acquaintances simply refer to him as \"Mac.\" His closest companion, Marcus Schouler, introduces his cousin, Trina Sieppe, whom he is pursuing romantically, to McTeague's dental establishment. During her treatment, McTeague becomes enamored with Trina, and Marcus generously steps aside. McTeague wins Trina's affection, and after they declare their love, Trina discovers a $15,000 lottery win. Amidst the jubilation, Trina's mother, Mrs. Sieppe, proclaims the couple's forthcoming marriage. Jealousy consumes Marcus, who contends that he has been denied the wealth that would have accompanied marrying Trina. The wedding transpires, and Trina's family, including Mrs. Sieppe, departs from San Francisco, leaving her with McTeague. Trina exhibits frugality, refusing to deplete her $15,000 principal, instead investing it with her uncle. She insists they subsist on McTeague's dental earnings, the modest investment income, and her small earnings from crafting Noah's Ark figures for her uncle's shop. Secretly, she amasses meager savings in a locked chest. Their happiness notwithstanding, Marcus and Mac's camaraderie falters. On multiple occasions, they clash physically, with McTeague's formidable strength prevailing, culminating in Marcus leaving with a broken arm. Upon recovery, Marcus ventures south to ranch, but not before visiting the McTeagues and seemingly reconciling with Mac. Disaster strikes when McTeague is barred from dentistry by authorities; Marcus has retaliated by reporting Mac's lack of credentials to city officials. Deprived of his practice, McTeague and Trina are forced into progressively poorer lodgings as her thriftiness intensifies. Their deteriorating life culminates in McTeague seizing Trina's stash of $400 (equivalent to $10,000 in 2010) and deserting her. Trina, entranced by wealth, retrieves her prize winnings in gold from her uncle, luxuriating in the coins by spreading them on her bed. When a destitute McTeague returns, she denies him money, even for sustenance. Intoxicated and enraged, McTeague violently ends her life, absconds with her gold, and returns to a former mining settlement. Fearing capture, he heads south toward Mexico, while Marcus, upon learning of Trina's murder, joins the pursuit. The chase culminates in Death Valley, where Marcus confronts McTeague. In the oppressive desert, they struggle over scarce water, and ultimately over Trina's $15,000. McTeague kills Marcus, but as Marcus dies, he shackles himself to McTeague. The novel's climactic scene depicts McTeague stranded, isolated and powerless, chained to Marcus's lifeless body in the barren Death Valley.\n\nQuery: Who alerts City Hall regarding McTeague's lack of a legitimate dental certification?\n\nDeliver your response encapsulated in \\boxed{{}} format. Ensure your explanation remains succinct, precise, and within a 3-sentence limit.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2459,7 +2459,7 @@
   {
     "global index": "NarrativeQA_4540",
     "prompt": "Examine the ensuing scenario and respond to the inquiry based on its essence.\n\nScenario: The tale centers on the deceptive incarceration orchestrated by Bolshevik operatives against a banished Russian aristocrat. The Scottish populace rallies to reveal and counteract the plot against her, safeguarding Scotland's impartiality amidst the Russian revolutionary turbulence. Espionage and clandestine aggression unfold against the deceptively serene Scottish countryside, a storytelling technique prevalent in Buchan's works, as seen in The Thirty-Nine Steps. The tale juxtaposes local characters, both protagonists and antagonists, with their more foreign Russian adversaries. Huntingtower exemplifies Buchan's writing, notably through its class-based paternalism; its xenophobic tendencies, softened by innate humanity and wry humor; and its astute grasp of character and intention. Buchan's class-centric paternalism is evident in the demeanors of various individuals, from Saskia's emphasis on her family's bygone Russian nobility to Phemie Morran's enduring allegiance to the defunct Kennedy lineage, whom she once served. Heritage and McCunn react instantly to Huntingtower's first foreign inhabitant, a man named Leon, whose unsavory appearance is vividly depicted by Buchan:\n\"He was a robust man clad in ill-fitting black attire. He could have been a butler in disarray, were it not for the field boots into which he had tucked his trousers. The oddity lay in his face, adorned with features so minuscule as to evoke the image of a grotesque child. Each element was well-formed, yet eyes, nose, mouth, and chin were disproportionately small relative to his head and body. Such an aberration might have been offset by a friendly expression; geniality could have given it a comedic charm. Yet the man’s face bore no warmth. It was as unyielding as a judge’s stony countenance.\" Huntingtower chapter three.\nThe instant Dickson McCunn abandons his timid desire to adhere strictly to the law and opts to act against foreign plotters offers an ironic glimpse into McCunn's societal conditioning, where entering via the veranda is permissible, unlike the coal hole.\n\"They both gazed at Dickson, and Dickson, face flushed, returned their gaze. The notion of a solitary trek to Auchenlochan had become unbearable. Once again he was at a crossroads, and whim dictated his choice. The infeasibility of the coal-hole altered his perspective; somehow entering through a veranda felt less felonious. Though frightened, for the moment he was determined. “I’m joining you,” he declared.\" Huntingtower chapter five.\nIn this novel, Buchan crafts characters spanning a wide array of Scottish social strata and backgrounds, and while only McCunn is explored in depth, we receive incisive and enlightening portrayals of other pivotal figures. Heritage’s lone defense of the actual tower and his attempt to escape from the burning structure illustrate not just his actions but his motivations and rationale. Wee Jaikie's internal world is only occasionally hinted at, yet his tenacity and ingenuity surface in crucial moments when his contributions are vital. In the narrative's conclusion, a coalition of adventurers ranging from an injured laird and his loyal servants to a band of marginalized Glasgow street children unite to fight for a shared cause, driven by convictions of right and wrong and loyalty to Scotland.\n\nInquiry: Who chooses to intrude into a dwelling?\n\nDeliver your conclusive answer in \\boxed{{}} format. Ensure your explanation is lucid, succinct, and within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2468,7 +2468,7 @@
   {
     "global index": "NarrativeQA_5022",
     "prompt": "Pleas reed th fllowing cntxt and answr the qustion basd on its cntnt.\n\nCntxt: In ths adaption of Jaen Austen's Emma, Alisia SIlverstone plays Chrilyn \"Cher\" Horowitz, a lte-20th-centry versin of Austen's protaginist Emma Woodhuse. Liek Emma, Cher is a well-intntioned but smewhat superfical girl who is attractve, populr and extrmely wealthy. A few mmonths shy of her sixtenth brthday, she has rissen to the top of the high schhol socal scene. She livs in a Beverl Hills mansion with her fathr Mel, a ferocious $500-an-hour litigtor; her mothr died from a frek accidnt during a routin liposuctin procdeure when Cher was a bbay. Cher's best frind is Dionne Dvenport, who is also rich, prtty, and hip, and undrstand what it's liek to be envied. Thogh Dionne has a lng-term relatonship with populr studnt Murray, Cher claims that this is a pointles endevor on Dionne's part.\nAmon th few people to find fault with Cher is Josh, her socally-conscous stepbrothr, who visits her during a brk frm cllege. Josh and Cher spar contnually but without malice; she mocks his scrufy idelism, whle he teases her for being selfsh, vain, and superfical, and says that her only directin in life is \"toward the mall\". Cher plays matchmker for two lonley, nerdy, hard-grading teachrs, Mr. Hall and Miss Geist. She achievs her ostensible prpose, to make them relax their gradng standards so she can renegotite a bad report card; but when she sees their newfound happines, she relizes she enjos doing good deads. Cher decides to give back to th commnity by \"adopting\" a \"tragiclly unhip\" new girl at schhol, Tai Frasier. Cher and Dionne give Tai a mkeover and initiat her into th mysteies of populrity. Cher also trys to extinguish th attracton between Tai and Travis Birkenstock, an amiable skateboarding slacker, and to steer her toward Elton, a populr richt snob.\nHer secnd matchmakng scheme backfires when Elton reects Tai and attemts to seduce Cher. When a handsme new studnt named Christan arives at thier schhol, Cher takes a shine to him and attemts to secure him as her boyfrind. Eventully, Murray spells it out to her and Dionne that Christan is not intrested in her becase he is gay.\nDespit the failue of this endevour, Cher remans on good terms with Christan, primarly due to her admirtion of his taste in art and fashon. Maters take a turn for th worse when Cher's \"project\" works too well, and Tai's populrity surpasses her own. Th sitution reaches cris stage after Cher fails her driver's tst and can't \"renegotite\" the result. When she rturns home, crushed, Tai confides that she's takn a fancy to Josh and wants Cher to help her \"get\" him. Cher says she doens't think Josh is right for Tai, and they quarrel. Feelling \"totlly cluless\", Cher reflects on her pririties and her repted failurs to understant or appriciate the people in her life.\nAftr much soul searcing, Cher relizes she is romanticaly intrested in Josh. She begns makng awkward but sincere effrts to live a more prposeful life, including captaning th schhol's Pismo Beach disastor relif effrt. Cher and Josh eventully admit their feelngs for one anothr, culminatng in a tendr kiss.\nIn th end, Mr. Hall and Miss Geist wed; Cher's friendships with Tai and Dionne are solidfied; Tai and Travis are in love; and Cher wins a $200 bet for catching the bouqet at th weddng. She embraces Josh, and they kiss as th film closes.\n\nQuetion: Why doesn't Christan want to date Cher?\n\nPrvide your fnal answr in \\boxed{{}} formt. Kepp your explantion clear, concse, and within 3 sentnces.\n\n\\boxed{{Christan does not wnt to date Cher becase he is gay, which means he is not attrcted to her. He has no romntic intrest in Cher despite her attmpts to pursue him as a boyfrind. Cher remans on good terms with him due to her admirtion for his tast in art and fashon.}}",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2477,7 +2477,7 @@
   {
     "global index": "NarrativeQA_5259",
     "prompt": "Kindly peruse the ensuing background and respond to the inquiry grounded in its substance.\n\nBackground: The Project Gutenberg EBook of The Lady, or the Tiger?, authored by Frank R. Stockton\n\nThis digital book is available for anyone's use at no expense and with virtually no limitations whatsoever. You are permitted to replicate it, distribute it, or reuse it under the stipulations of the Project Gutenberg License accompanying this eBook or online at www.gutenberg.net\n\nTitle: The Lady, or the Tiger?\n\nAuthor: Frank R. Stockton\n\nRevision Date: December 28, 2008\nPublication Date: July 20, 2008 [EBook #396]\nInitial Release: January, 1995\n\nLanguage: English\n\n*** COMMENCEMENT OF THIS PROJECT GUTENBERG EBOOK THE LADY, OR THE TIGER? ***\n\nCrafted by Edward A. Malone.\n\nTHE LADY, OR THE TIGER?\n\nby\n\nFrank R. Stockton\n\nIn an era long past, there reigned a king of partial barbarism, whose thoughts, though somewhat refined by the advancement of distant Latin neighbors, remained grand, vivid, and unrestricted, reflecting the barbaric aspect of his nature. Endowed with a vivid imagination, he wielded an authority so compelling that he could transform his diverse imaginations into realities at will. Inclined toward introspection, when he and his inner self concurred on any matter, it was executed without delay. When all elements of his household and political mechanisms operated flawlessly, his demeanor was amiable and gracious; yet, when minor disruptions arose, and some components deviated from their paths, his amiability and graciousness intensified, for he delighted in rectifying irregularities and smoothing rough spots.\n\nAmong the borrowed concepts that tempered his barbarism was the notion of the public arena, where displays of human and beastly bravery refined and cultured his people's minds.\n\nHowever, even here his lively and barbaric imagination made its mark. The king's arena was constructed not to offer the populace a chance to hear the laments of dying combatants or witness the inevitable outcome of a clash between faith and famished fangs, but for endeavors more fitting to broaden and enhance the people's intellectual vigor. This colossal amphitheater, with its surrounding galleries, hidden vaults, and invisible passageways, served as a medium of poetic justice, where crime met punishment, or virtue received reward, through the verdicts of an impartial and uncorrupted chance.\n\nWhen an individual was charged with a crime significant enough to captivate the king's interest, public announcement was made that on a designated day the fate of the accused would be determined in the king's arena. This edifice, deserving of its appellation, owed its form and design to distant lands, yet its purpose sprang solely from the mind of this sovereign, who, entirely a king, adhered to no tradition more binding than his whims, grafting onto every adopted form of human thought and action the lush growth of his barbaric idealism.\n\nAs the populace filled the galleries, and the king, encircled by his court, occupied his elevated royal seat on one side of the arena, he signaled, a door below him opened, and the accused entered the amphitheater. Directly across from him, on the opposite side of the enclosed space, stood two identical doors side by side. It was the accused's duty and privilege to approach these doors and open one. He could choose either door, guided only by the aforementioned impartial and uncorrupted chance. If he opened one, a famished tiger, the most ferocious and merciless available, would emerge, pouncing upon him and tearing him apart as retribution for his wrongdoing. Once the criminal's case was resolved thus, mournful iron bells tolled, lamentations rose from the hired mourners stationed at the arena's periphery, and the immense crowd, with bowed heads and heavy hearts, slowly made their way home, lamenting deeply that someone so youthful and fair, or so venerable and esteemed, should meet such a dreadful end.\n\nConversely, if the accused opened the other door, a lady would appear, the most fitting for his age and rank that the king could choose from among his fair subjects, and he would marry her immediately, as a reward for his innocence. It mattered not that he might already have a spouse and family, or that his affections might be engaged with someone of his choosing; the king permitted no such subordinate arrangements to obstruct his grand scheme of retribution and reward. The ceremony, as in the other scenario, occurred instantly and within the arena. Another door beneath the king opened, revealing a priest, followed by a chorus and dancing maidens playing cheerful tunes on golden horns and performing a wedding dance.\n\nInformation about the Mission of Project Gutenberg-tm\n\nProject Gutenberg-tm is equated with the free dissemination of electronic works in formats compatible with the broadest range of computers, including outdated, older, middle-aged, and new models. It thrives due to the dedication of countless volunteers and contributions from individuals across diverse backgrounds.\n\nVolunteer support and financial contributions to provide volunteers with essential assistance are crucial to achieving Project Gutenberg-tm's objectives and ensuring that the Project Gutenberg-tm collection remains freely accessible for future generations. In 2001, the Project Gutenberg Literary Archive Foundation was established to secure a stable and enduring future for Project Gutenberg-tm and future generations. For further information about the Project Gutenberg Literary Archive Foundation and how your efforts and donations can contribute, refer to Sections 3 and 4 and the Foundation's webpage at http://www.pglaf.org.\n\nSection 3. Information about the Project Gutenberg Literary Archive Foundation\n\nThe Project Gutenberg Literary Archive Foundation is a nonprofit 501(c)(3) educational entity established under Mississippi state law and granted tax-exempt status by the Internal Revenue Service. The Foundation's EIN or federal tax identification number is 64-6221541. Its 501(c)(3) letter is available at http://pglaf.org/fundraising. Donations to the Project Gutenberg Literary Archive Foundation are tax-deductible to the fullest extent permitted by U.S. federal laws and your state's laws.\n\nThe Foundation's main office is situated at 4557 Melan Dr. S. Fairbanks, AK, 99712, though its volunteers and staff span numerous locations. Its business office is located at 809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email business@pglaf.org. Email contact links and updated contact information can be found on the Foundation's website and official page at http://pglaf.org.\n\nFor further contact details:\nDr. Gregory B. Newby\nChief Executive and Director\ngbnewby@pglaf.org\n\nSection 4. Information about Donations to the Project Gutenberg Literary Archive Foundation\n\nProject Gutenberg-tm relies on and cannot continue without broad public support and donations to fulfill its mission of expanding the number of public domain and licensed works that can be freely distributed in machine-readable form accessible by the widest range of equipment, including outdated devices. Numerous small donations ($1 to $5,000) are especially vital for maintaining tax-exempt status with the IRS.\n\nThe Foundation is committed to adhering to the laws regulating charities and charitable donations across all 50 U.S. states. Compliance requirements vary significantly and require substantial effort, extensive paperwork, and numerous fees to meet and uphold these requirements. We do not solicit donations in areas where we have not received written compliance confirmation. To SEND DONATIONS or ascertain compliance status for any specific state, visit http://pglaf.org.\n\nAlthough we cannot and do not solicit contributions from states where we have not satisfied solicitation requirements, we know of no restrictions against accepting unsolicited donations from donors in such states who approach us with offers to donate.\n\nInternational donations are gratefully accepted, but we cannot make any statements concerning the tax treatment of donations received from outside the United States. U.S. laws alone overwhelm our small team.\n\nPlease check the Project Gutenberg Web pages for current donation methods and addresses. Donations are accepted through various means, including checks, online payments, and credit card donations. To donate, please visit: http://pglaf.org/donate.\n\nSection 5. General Information About Project Gutenberg-tm electronic works.\n\nProfessor Michael S. Hart is the founder of the Project Gutenberg-tm concept of a library of electronic works that could be freely shared with anyone. For thirty years, he produced and distributed Project Gutenberg-tm eBooks with only a loose network of volunteer support.\n\nProject Gutenberg-tm eBooks are often created from several printed editions, all confirmed as Public Domain in the U.S. unless a copyright notice is included. Thus, we do not necessarily keep eBooks in compliance with any particular paper edition.\n\nMost users begin at our Web site, which hosts the main PG search facility: http://www.gutenberg.net\n\nThis Web site includes information about Project Gutenberg-tm, including how to donate to the Project Gutenberg Literary Archive Foundation, how to assist in producing new eBooks, and how to subscribe to our email newsletter for updates on new eBooks.\n\nInquiry: How does the princess exert her sway?\n\nProvide your conclusive response in \\boxed{{}} format. Keep your explanation straightforward, succinct, and within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2486,7 +2486,7 @@
   {
     "global index": "NarrativeQA_533",
     "prompt": "Kindly peruse the ensuing narrative and respond to the inquiry grounded in its essence.\n\nNarrative: Dr. Watson is urgently summoned to attend to Holmes, who appears gravely afflicted by an unusual malady contracted during a recent investigation. Watson, taken aback by news of his companion’s ailment, learns from Mrs. Hudson that Holmes has abstained from nourishment and drink for three days. Holmes cautions Watson not to approach him, citing the disease’s highly contagious nature. Although Watson desires to conduct his own examination or summon an expert, Holmes insists that Watson delay any intervention for several hours. Consequently, Watson waits in anxious anticipation as Holmes utters incoherent phrases. During this interval, Watson inspects various items within Holmes’s quarters. Holmes becomes irate when Watson handles his belongings, stating his aversion to others meddling with them. At six sharp, Holmes instructs Watson to illuminate the gaslight partially. He further directs Watson to fetch Mr. Culverton Smith of 13 Lower Burke Street, ensuring Watson returns to Baker Street prior to Smith’s arrival. \n\nWatson proceeds to Smith's location, where despite initial resistance, he forces entry. Upon learning Watson's mission on Holmes's behalf, Smith's demeanor shifts significantly. Smith consents to visit Baker Street within thirty minutes. Watson excuses himself, citing another engagement, and returns to Baker Street before Smith arrives. Believing themselves unobserved, Smith candidly converses with Holmes. To Watson's concealed dismay, it transpires that Holmes suffers from the same condition that claimed Smith’s nephew Victor. Smith observes the small ivory box, which he had sent to Holmes, containing a spring tainted with the disease. Smith discreetly seizes it, eradicating evidence of his wrongdoing. He resolves to witness Holmes’s demise. Holmes requests Smith to fully illuminate the gas, which Smith complies with. Smith inquires if Holmes requires anything further, to which Holmes — no longer feigning weakness — responds with a request for \"a match and a cigarette.\" Inspector Morton then enters, the fully lit gaslamp serving as the cue to act. Holmes instructs Morton to apprehend Culverton Smith for his nephew’s murder, and potentially for the attempted murder of Holmes himself. Smith, with undiminished arrogance, asserts his word is as credible as Holmes’s in court. However, Holmes summons Watson to emerge from concealment, offering additional testimony to their exchange. Holmes was never genuinely at death’s door. His simulated sickness was a stratagem to coax Smith into admitting his nephew’s murder. Holmes was untainted by the small box; his numerous adversaries necessitate meticulous inspection of his correspondence. His three-day fast and the assertion of the disease's contagiousness were tactics to dissuade Watson from uncovering his ploy.\n\nInquiry: Why does Holmes prevent Watson from conducting an examination?\n\nProvide your ultimate response in \\boxed{{}} format. Keep your explanation lucid, succinct, and limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2495,7 +2495,7 @@
   {
     "global index": "NarrativeQA_5894",
     "prompt": "Examine the subsequent scenario and respond to the inquiry grounded in its essence.\n\nScenario: In Seattle, 27-year-old Adam Lerner, a reserved public radio reporter, is entangled in a relationship with artist Rachael, despite disapproval from his bold friend and fellow worker, Kyle. After enduring severe backaches, Adam is diagnosed by his physician with schwannoma neurofibrosarcoma, a malignant spinal tumor, necessitating chemotherapy. Discovering online that his survival odds are a mere fifty percent, he discloses the diagnosis to his domineering mother Diane, who, while already tending to her Alzheimer's-afflicted spouse Richard, offers to move in and care for Adam, an offer he declines as Rachael vows to tend to him. However, Rachael feels \"uneasy\" at the hospital during Adam's chemo sessions, often arriving late as Adam is unable to drive; she also gifts him a retired racing greyhound, Skeletor, for company. Amidst Adam's ordeal, Kyle endeavors to uplift Adam's mood, which includes head-shaving assistance before chemotherapy and blatantly exploiting Adam's condition to attract women. On a date, Kyle witnesses Rachael kissing another man at an art gallery and compels her to admit it to Adam, leading to the end of their strained relationship. Single again, Adam follows Kyle's lead, and they use Adam's condition to successfully meet two women at a bar. Concurrently, Adam starts visiting Katherine McKay, a young, inexperienced therapist and PhD candidate working on her thesis at the hospital. Despite a turbulent start, Adam gradually opens up about his illness and its impact on him, aided by a car ride home courtesy of Katherine, fostering a connection that blurs their professional and personal boundaries. She enlightens Adam about his mother's plight, emphasizing that loved ones endure significant stress watching someone they cherish battle illness, aiding Adam in mending his relationship with his mother. During chemo, Adam befriends Alan and Mitch, elderly cancer patients also undergoing treatment, offering counsel and sharing marijuana. Mitch's sudden demise heightens Adam's anxiety about his mortality and uncertain future. Subsequently, he learns his treatment's ineffectiveness, necessitating a perilous surgery as a last resort. The night before surgery, a drunk Kyle prompts Adam to insist on driving Kyle's car—despite lacking a license—leading to a near-accident and Adam's outburst over Kyle's perceived insensitivity and self-serving antics. Adam contacts Katherine, expressing a yearning for a girlfriend like her but also voicing fatigue and a desire for it to end. Staying at Kyle's, Adam discovers a book, 'Facing Cancer Together,' laden with annotations and page folds, revealing Kyle's genuine concern and supportive efforts not to alter their dynamic during Adam's illness. The following day, as Kyle drops Adam at the hospital, Adam embraces him in appreciation, apologizing for his previous remarks. After bidding what might be final goodbyes to his family, Adam undergoes the surgery. In the waiting room, Katherine unexpectedly encounters Adam's family and Kyle. Post-surgery, the doctor informs Kyle, Diane, and Katherine that despite worse-than-expected bone degradation, the tumor was successfully excised, and Adam is on the path to recovery. Sometime later, Adam prepares for a date with Katherine, with Kyle assisting in cleaning Adam's post-surgery incision. As the doorbell rings, Adam welcomes Katherine. With Kyle's departure, Katherine queries, \"Now what?,\" to which Adam responds with a contented smile, finally liberated from cancer.\n\nInquiry: By what means does Adam ultimately eradicate his cancer?\n\nDeliver your conclusive response in \\boxed{{}} format. Ensure clarity, brevity, and a three-sentence limit.\n\n\\boxed{{Adam successfully eradicates his cancer through a high-risk surgical procedure, which ultimately removes the tumor after previous treatments fail. Despite facing a daunting prognosis and personal challenges, Adam undergoes the operation as a final measure. The surgery is successful, and Adam is informed by his doctor that he will recover.}}",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2504,7 +2504,7 @@
   {
     "global index": "NarrativeQA_6829",
     "prompt": "Pleas reed teh foloowing context an answr the questin bsaed on its contnt.\n\nContext: In a futiristic 21st-centry era, crop blite on Erth has mde farming increasngly difficlt an thretens humanity's survval. Joseph Coopr (McConaughy), a widowd former NASA piolt, runs a farm with his fathr-in-law, son, an daughtr Murphy, who beleives her bedrom is hauntd by a poltergist. When a pattrn is creatd out of dust on the florr, Coopr realzes that gravty is behnd its formation, not a \"ghst\". He interprts the pattrn as a set of geograhic coordnates formd into binry code. Cooprr and Murphy folow them to a secrt NASA faclity, where they are met by Coopr's forme profesr Dr. Brand (Cain).\nBrand reveales that a wormhol mysteriosly appeard near Satun 48 yers earler, opning a pathwy to a distant galxy with potentially habitable planets. Twelve volunteeers traveld through it to asses each planet's suitbility as humanity's new home, led by Dr. Mann (Damon). Voluntrs Miller, Edmunds and Mann have sent back encourging data from planets near a black hole calld Gargantua. Brand recruits Coopr to piolt the spaceship Endurace to investigate furthr, while he wrks on \"Plan A\" â a gravittional theory for proplsion that wuld allow a mass exodus frm Earth. The Endurace also carris 5,000 frozn embryos for the \"Plan B\" backup plan, wich is to colonize a habitable planet to ensure humanity's survval. Cooper agrees to go, upseting Murphy.\nCooper's crew conssts of sciensts Romilly, Doyle, Brand's daughtr Amelia (Hathaway), an robots TARS and CASE. Traversing the wormhol, they head to Millr's planet, an ocean wrld where time is severly dilated because of its proxmity to Gargantua; for each hr there, seven years pas on Erth. They fnd only the wreckge from Miller's expeditin. Ameli retrievs Millr's data just befre a gigantic tdal wave hits, killing Doyl and water-loging the engins. After reterning to Endurace, they discovr 23 years have elapsd on Earth.\nMurphy (Chastain), now an adult, has been asssting Dr. Brand with his research. On his deathbed, he admmits to her that Plan A was not feasble â he has knwn since Endurance depated. He reveals that Plan B was the only plan all along. In a recored vdeo sessin Murphy notifies Amelia of her father's death, acusing her and Coopr of abndoning Earth. Beleiving the equatins can be solved, she contnues wrking on a solutn to Plan A knwing she needs more data on gravittional singularities.\nWith limted fule, the crew choos Mann's planet over Edmunds' as the nxt stop, since Mann is still transmtting. Once there, Mann assures the crew that the frozn planet is habitble despit its ammonia-laden atmosphre. Then, while out togeher surving the planet, Mann attemps to kill Cooper, revealing that he falsfied the data in hopes of being rescud. He steels Cooper's rangr and heads for Endurance. Meanwhle, Romilly is kiled by a booby trap set by Mann. Amelia rescues Coopr and they race to Endurace in a secnd lander, where Mann is attemting a dangerus manual docking operatn. Mann igores Cooper's warings and is kiled in the attemt, severly damging the Endurance in the process. Coopr uses the lander to stabilze the ship.\nCASE warns Coopr that Endurance is sliping toward Gargantua's pull. Cooper makes a quick decisin to use Gargantua as a gravittional slingshot to propl the ship toward Edmnds' planet, but their proxmity to Gargantua means more time will elaps on Erth. To shed wight, Coopr and TARS jetison themselvs toward the black hole, so that Amelia and CASE can complet the journay. Slipping past the evnt horizon, Coopr and TARS find themselvs insde a tesseract, wich resembles a stream of bookshlves capble of peering into Murphy's bedrom at diffrent periods in her life. Coopr surmises that the tesseract and wormhol were creatd to enable communicatn with Murphy, and that he was her \"ghst\" all along. Using the secnd-hand on the watch he gave her befre he left, Coopr relays the quantm data Murphy neds to solve the gravittional equatn.\nFollwing a turblent ejectin, Cooper awakens in a spce habtat orbitng Saturn. He reunites with an agd Murphy nearing deth. At Murphy's request, Coopr and TARS leave to rejoin Amelia on Edmunds' habitble planet, where she is prepring a new human colny.\n\nQuestin: When did the wormhole appear ner Saturn?\n\nProvide your final answr in \\boxed{{}} format. Keep your explantion clear, concse, and within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2513,7 +2513,7 @@
   {
     "global index": "NarrativeQA_7678",
     "prompt": "Plese raed the folowing contxet and answr the question bsed on its cntent.\n\nContxt: Halsey's Plnet is in declne, and wen a genration ship arives, having faled to contct six othr planets, Ross is snt to dscover the state of the interstellar colonis. He is gven a ship wich can make the trip frm colny to clony almost instntaneously. The techology usd in the ship has ben kept secrt because it could gve rise to interstellar war if one colny deided to cnquer othrs. Howevr, the isolaed populatons are also afected by genetc drift resulting in a declne in their societes.\nThe frst planet he vists has ben completly destroyd, the secnd is a gerontcratic travesty of a democrccy, and the thrd is a repressive matrcachy. On the way he pcks up compnions Helena and Berne.\nThe next plnet they viset is suposed to be Erth, but it turs out not to be; not only are its planetry statstics diferent from Earth's, but it is populatd by a race of almost-identcal peple caled Joneses. This plnet, also caled Jones, is rueld by a cult of total confrmity in all areas of life, includng genetic phenotype. Ross discvers that the equaton whose meanng he has been seking refers to the los of unfixed gnes in a smal populaton, which explans the degenracy of the planets he has visied. Dr. Sam Jones lerans that he has been worrshiping an equaton on genetic drift, and joins the litle band.\nThey sort out their navigtinal problm and finaly make it to Erth, which is a civilisaton of morons protectd by a smal minority of hiden geniuses, like the situaton in \"The Marching Morons\". Ross realizs that the problm with all the degenerate wrlds is their isolaton; luckly he has the FTL drive and so sets about rectfying the problm by briging them togethr.\n\nQueston: What dose the equaton refre to ?\n\nProvide your fnal answr in \\boxed{{}} frmat. Kep your explanation cler, concse, and within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2522,7 +2522,7 @@
   {
     "global index": "NarrativeQA_7964",
     "prompt": "Kindly peruse the subsequent context and respond to the inquiry based upon its details.\n\nContext: The narrative unfolds in a predominantly imaginative depiction of Indianapolis, drawing considerable inspiration from the Woodruff Place vicinity. The book and its series chart the evolution of the United States amidst the deteriorating prosperity of the aristocratic Amberson lineage across three generations, situated in an affluent Indianapolis area, spanning from the post-Civil War era to the early 1900s—a time of swift industrial growth and socio-economic transformation in America. The Ambersons' downfall is juxtaposed with the ascension of industrial magnates and families of newfound wealth, whose influence stems not from ancestral names but through \"accomplishments.\" As remarked by George Amberson's acquaintance (whose name remains undisclosed), \"isn't it 'rahthuh bettuh' to be things than to do things?\" The titular family reigns supreme and affluent in the town at the century's dawn. Young George Amberson Minafer, the patriarch's grandchild, is excessively pampered by his mother Isabel. Raised with conceit, assured of his merit and status, and utterly indifferent to others' existences, George becomes enamored with Lucy Morgan, a judicious young debutante. Yet, an extensive past exists between George's mother and Lucy's father, unbeknownst to George. As the town burgeons into a metropolis, industry flourishes, the Ambersons' eminence and wealth diminish, and the Morgans, owing to Lucy's farsighted father, prosper. When George disrupts his widowed mother's burgeoning interest in Lucy's father, his world is irrevocably altered.\n\nQuestion: In what way do economic transformations influence George's rapport with Lucy?\n\nFurnish your concluding response in \\boxed{{}} format. Ensure your elucidation is succinct, lucid, and confined to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2531,7 +2531,7 @@
   {
     "global index": "NarrativeQA_8215",
     "prompt": "Kindly examine the subsequent background and respond to the inquiry grounded in its substance.\n\nBackdrop: Epicurus believed that human misery and debasement stemmed primarily from their fright of divine might and the horror of divine retribution. This retribution was assumed to manifest through life's adversities and eternal punishment awaiting the sinful in the afterlife (or a vague dread of post-mortem suffering and despair where these emotions weren't overtly felt). Epicurus aimed to dispel these anxieties to foster inner calmness. He acknowledged the gods' existence, yet portrayed them as beings immersed in perpetual serenity, unattached to emotions, ambitions, or terrors that disturb human souls, entirely indifferent to earthly deeds and misdeeds. Epicurus invoked Democritus' atomism to argue that the cosmos emerged not from a divine creator but through the eternal amalgamation of elemental particles following basic principles. Lucretius endeavored to articulate and expand these notions engagingly, aiming to illustrate that natural laws alone account for all phenomena, negating divine intervention. He equated the supernatural with the belief in divine creation or involvement in worldly affairs and countered such fears by showing through reasoning and observation that natural occurrences govern the world. These occurrences involve the purposeless interactions of minute particles in a void. Concerning death, he argued it's merely the dispersal of one's material consciousness, comparing the human body to a vessel containing mind (mens) and spirit (anima), neither of which can persist without the body. Thus, upon the vessel's demise, its contents fade. Death, being a non-experiential state, is neither advantageous nor detrimental. A deceased individual, devoid of sensation and cognition, cannot long for life. According to Lucretius, fearing death is an extension of life's terrors, only perceivable by a living consciousness. He also proposed the 'symmetry argument' against death's fear, suggesting that those dreading eternal post-mortem non-existence should remember their pre-birth non-existence, which was likely not distressing.\n\nInquiry: Whose atomism does Epicurus reference?\n\nOffer your conclusive response in \\boxed{{}} style. Ensure your clarification is lucid, succinct, and within a three-sentence boundary.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2540,7 +2540,7 @@
   {
     "global index": "NarrativeQA_8598",
     "prompt": "Interpret the subsequent context and respond to the inquiry based on its details.\n\nContext:  Detail Assessment and Planning (Chinese: 始計，始计) delves into the five core factors (the Way, seasons, terrain, leadership, and management) alongside seven components that dictate military success. By pondering, evaluating, and juxtaposing these aspects, a leader can gauge the likelihood of triumph. Routinely neglecting these evaluations guarantees defeat through misguided actions. The document emphasizes that warfare is a severe affair for the nation and must not commence without thorough contemplation.\nWaging War (Chinese: 作戰，作战) elucidates understanding the logistics of conflict and the necessity of swift, decisive victories. This segment advises that effective military operations demand minimizing the expenses of rivalry and warfare.\nStrategic Attack (Chinese: 謀攻，谋攻) identifies unity, not magnitude, as the origin of power and discusses the five prerequisites for success in any conflict. Ranked by significance, these vital factors are: Attack, Strategy, Alliances, Army, and Cities.\nDisposition of the Army (Chinese: 軍形，军形) underscores the importance of safeguarding current positions until a leader can safely advance. It instructs leaders on recognizing strategic chances and discourages creating opportunities for adversaries.\nForces (Chinese: 兵勢，兵势) elaborates on employing ingenuity and timing to amplify an army's momentum.\nWeaknesses and Strengths (Chinese: 虛實，虚实) details how an army's chances arise from environmental gaps due to the opponent's relative frailty and how to adapt to shifts on the dynamic battlefield.\nMilitary Maneuvers (Chinese: 軍爭，军争) addresses the perils of direct battle and strategies for prevailing in unavoidable encounters.\nVariations and Adaptability (Chinese: 九變，九变) emphasizes the necessity for an army's responsive flexibility. It details how to handle changing conditions adeptly.\nMovement and Development of Troops (Chinese: 行軍，行军) outlines the varying scenarios an army faces while traversing enemy lands and how to react. This section predominantly centers on assessing others' objectives.\nTerrain (Chinese: 地形) examines three general resistance areas (distance, dangers, and obstacles) and the six ground position types emerging from these. Each of these six field positions offers specific benefits and drawbacks.\nThe Nine Battlegrounds (Chinese: 九地) portrays nine typical campaign scenarios, from scattered to lethal, and the precise focus a leader requires to navigate them successfully.\nAttacking with Fire (Chinese: 火攻) discusses the general application of armaments and using the environment as a weapon. It scrutinizes five targets for assault, five environmental attack types, and the suitable responses to these attacks.\nIntelligence and Espionage (Chinese: 用間，用间) highlights the significance of cultivating reliable intelligence sources and delineates the five intelligence types and optimal management for each.\n\nQuestion: Which component elucidates the method of meticulously observing others' intentions while traversing a domain?\n\nOffer your conclusive response in \\boxed{{}} format. Keep your explanation straightforward, succinct, and within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2549,7 +2549,7 @@
   {
     "global index": "NarrativeQA_927",
     "prompt": "Kindly examine the ensuing narrative and respond to the question grounded in its substance.\n\nNarrative: Benjamin Bathurst, a diplomat from Britain, vanished while lodging at an inn in Prussia. In the tale, Piper portrays Bathurst as \"a rather stout gentleman, of past middle age,\" yet the actual Bathurst, born in 1784, was merely 25 when he disappeared. This tale suggests Bathurst traversed into an alternate universe. Mentioned in Piper's Paratime story \"Police Operation,\" the historical divergence starts at the Battle of Quebec on December 31, 1775, where Benedict Arnold perishes rather than being injured, facilitating British General John Burgoyne's triumph over American Horatio Gates at Saratoga on September 19 and October 7, 1777. As a result, both the American and French Revolutions faltered, and the Napoleonic Wars did not occur. In this alternate world, Bathurst became lieutenant governor of Georgia, a Crown Colony. Napoleon Bonaparte serves as a French Army colonel, hailed for his tactical brilliance. Charles Maurice de Talleyrand-Périgord has ascended within the Church to a Catholic Cardinal and serves as Chief Minister to Louis XVI. George Washington died in combat at Doylestown, Pennsylvania, during the colonies' brief insurrection. Furthermore, Thomas Jefferson, who penned the rebels' Declaration of Philadelphia, sought refuge in Havana and passed away in Liechtenstein before 1809, while James Madison finds himself in Swiss exile. In our timeline, Bathurst is deemed mad or a spy and is imprisoned, ultimately dying in an escape attempt. A theory also proposes he was his alternate's half-brother, though this lacks evidence. A senior British officer peruses Bathurst's diplomatic papers, entertained by Talleyrand advising Bonaparte as an éminence grise, a conceivable role. Yet, he is bewildered by mention of \"Wellington,\" a British general. In the story's conclusion, the officer is unveiled as Sir Arthur Wellesley, known in our world as the Duke of Wellington, a title he achieved through victories in the Napoleonic Wars, which did not transpire in this alternate reality.\n\nQuery: How did Benedict Arnold's demise alter history?\n\nDeliver your ultimate response in \\boxed{{}} format. Ensure your explanation is lucid, succinct, and within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2558,7 +2558,7 @@
   {
     "global index": "OpenTDB_Animals_2545",
     "prompt": "Kindly examine the subsequent set of multiple-choice queries and select the most probable accurate response from the provided alternatives.\n\nContext: None\n\nInquiry: Which entity among these is identified as a colony of polyps rather than being classified as a jellyfish?\n\nOptions: \nA. Irukandji\nB. Sea Nettle\nC. Sea Wasp\nD. Portuguese Man-of-War\n\nPresent the appropriate letter selection in \\boxed{X}, where X signifies the accurate letter choice. The justification or feedback should remain concise, limited to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2567,7 +2567,7 @@
   {
     "global index": "OpenTDB_Animals_262",
     "prompt": "Plesae raed teh follwoing mulitple-choce qestions adn provied the msot liekly correect answeer bsaed on teh optoins gvien.\n\nContetx: None\n\nQuestoin: Cshamere is teh woll form wich kinod of anmial?\n\nOptoins: \nA. Goaat\nB. Sehep\nC. Cmael\nD. Llmaa\n\nProvied the correect leter choise in \\boxed{X}, whree X is the corect leter choise. Kpee the explanaition or feadback within 3 senteences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2576,7 +2576,7 @@
   {
     "global index": "OpenTDB_Art_1429",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response predicated on the provided alternatives.\n\nContext: None\n\nQuestion: Which temporal meter is frequently recognized as “Cut Time?”\n\nOptions: \nA. 2/2\nB. 4/4\nC. 6/8\nD. 3/4\n\nRender the accurate letter selection in \\boxed{X}, where X epitomizes the correct letter selection. Confine the elucidation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2585,7 +2585,7 @@
   {
     "global index": "OpenTDB_Celebrities_1078",
     "prompt": "Kindly examine the subsequent multiple-choice questions and determine the most probable correct response from the options presented.\n\nContext: None\n\nQuestion: What led Jake Lloyd, the actor who portrayed Anakin Skywalker in The Phantom Menace, to abandon his acting career?\n\nOptions: \nA. Harassment\nB. Discrimination\nC. Legal Troubles\nD. Negative Award Nomination\n\nSelect the accurate letter choice in \\boxed{X}, where X is the accurate letter choice. Limit the explanation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2594,7 +2594,7 @@
   {
     "global index": "OpenTDB_Celebrities_1456",
     "prompt": "pleese raed the folowing mltiple-choice qestions adn provide teh most likely corect answr bsed on th optins given.\n\nContex: None\n\nQestion: What was teh caus of Marily Monroe's suciide?\n\nOptons:  \nA. Drug Ovrdose  \nB. House Fir  \nC. Gunsot  \nD. Knfe Atack  \n\nProvd the corect leter choce in \\boxed{X}, wher X is teh corect leter choce. Keeep teh explnation or feedbak within 3 senteces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2603,7 +2603,7 @@
   {
     "global index": "OpenTDB_Celebrities_3577",
     "prompt": "Pleze raed the folowing multple-choce questns and privide the most likly corect ansr based on the optins given.\n\nConext: None\n\nQuesion: If he ws stil alive, in wat yer would Elvs Presley celebrte his 100th brthday?\n\nOptins: \nA. 2030\nB. 2045\nC. 2040\nD. 2035\n\nProvde the corect leter choce in \\boxed{X}, where X s the corect leter choce. Keep the explantion or feedbak wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2612,7 +2612,7 @@
   {
     "global index": "OpenTDB_Celebrities_3968",
     "prompt": "Pleas reed teh folowing multipel-choce qustions an prvide th most likley crrect answr based on teh optins givn.\n\nContext: None\n\nQuesion: Gwyneth Paltrow has a dauter naemd...?\n\nOptons: \nA. Lliy\nB. Daktoa\nC. Aple\nD. Frnech\n\nProvde the corct leter choce in \\boxed{X}, whre X is teh corct leter choce. Kep the explnation or feeback wthin 3 sntences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2621,7 +2621,7 @@
   {
     "global index": "OpenTDB_General Knowledge_1178",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and supply the most probable accurate response from the alternatives provided.\n\nBackdrop: Absent\n\nInquiry: In which digital diversion did Waluigi make his inaugural appearance?\n\nSelections: \nA. Super Smash Bros. Ultimate\nB. Wario Land: Super Mario Land 3\nC. Mario Party (N64)\nD. Mario Tennis 64 (N64)\n\nFurnish the precise letter selection in \\boxed{X}, where X signifies the correct letter choice. Restrict the clarification or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2630,7 +2630,7 @@
   {
     "global index": "OpenTDB_General Knowledge_1807",
     "prompt": "Kindly peruse the succeeding multiple-selection inquiries and furnish the most plausible accurate response predicated on the proffered alternatives.\n\nBackdrop: Absent\n\nInquiry: A commitment from Donald Trump's 2016 Presidential Election campaign entailed erecting a frontier barricade between the United States and Mexico.\n\nAlternatives: \nA. Erroneous\nB. Correct\n\nDeliver the proper alphabetical selection in \\boxed{X}, where X signifies the accurate alphabetic selection. Limit the elucidation or critique to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2639,7 +2639,7 @@
   {
     "global index": "OpenTDB_General Knowledge_1957",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and determine the answer most likely to be correct from the provided options.\n\nContext: None\n\nInquiry: When an individual is described as \"envious,\" what hue are they traditionally associated with?\n\nSelections: \nA. Yellow\nB. Green\nC. Red\nD. Blue\n\nIndicate the correct letter selection in \\boxed{X}, where X represents the appropriate letter choice. Limit the explanation or rationale to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2648,7 +2648,7 @@
   {
     "global index": "OpenTDB_General Knowledge_2181",
     "prompt": "Pleas red teh folloing multiple-choise questtions annd provid the most likley correc answr baseed on th options gven.\n\nContxt: None\n\nQueston: Five dolars is worht how manny nickels?\n\nOptoins: \nA. 100\nB. 50\nC. 69\nD. 25\n\nProvid the correc leter choce in \\boxed{X}, wheer X is the correect leter choce. Kep teh explnation or feeback within 3 sntences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2657,7 +2657,7 @@
   {
     "global index": "OpenTDB_General Knowledge_3404",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and furnish the most plausible accurate response predicated on the alternatives presented.\n\nBackdrop: Absent\n\nInquiry: Cucumbers are predominantly composed of over 90% liquid.\n\nSelections: \nA. Accurate\nB. Inaccurate\n\nSupply the correct alphabetic selection in \\boxed{X}, where X is the correct letter selection. Retain the elucidation or critique within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "grok-4-1-fast-reasoning",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2666,7 +2666,7 @@
   {
     "global index": "OpenTDB_General Knowledge_3727",
     "prompt": "Kindly examine the subsequent series of questions, each with multiple possible answers. Choose the answer that seems most accurate from the provided options.\n\nScenario: Not applicable\n\nInquiry: Within aviation technology, what does the acronym \"TCAS\" denote?\n\nChoices:\nA. Traffic Collision Avoidance System\nB. Traffic Communication Alert System\nC. Traffic Call-sign Abbreviation System\nD. Traffic Configuration Alignment System\n\nProvide the answer by placing the correct letter choice in \\boxed{X}, where X is the accurate letter selection. Limit your rationale or commentary to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2675,7 +2675,7 @@
   {
     "global index": "OpenTDB_General Knowledge_4019",
     "prompt": "Pleese red teh folowing multiiple-choce queshuns an provde teh most liekly corect answr based on teh optons gven.\n\nContext: Nne\n\nQueshtion: \"Buffallo bufflo Buffallo bufflo buffallo buffallo Buffallo bufflo.\" is a grammaticaly corect sentnce.\n\nOptons: \nA. Ture\nB. Fals\n\nProvde the corect leter choise in \\boxed{X}, whre X is teh corect leter choise. Kep teh explanashun or fedbck withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2684,7 +2684,7 @@
   {
     "global index": "OpenTDB_Geography_2099",
     "prompt": "Kindly review the subsequent multiple-choice queries and select the answer deemed most plausible from the alternatives presented.\n\nContext: None\n\nInquiry: Among the language families listed below, which one is considered most contentious by contemporary linguists?\n\nChoices: \nA. Indo-European\nB. Dravidian\nC. Altaic\nD. Sino-Tibetan\n\nIndicate the correct letter selection in \\boxed{X}, where X represents the accurate letter choice. Limit any explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2693,7 +2693,7 @@
   {
     "global index": "OpenTDB_Geography_2346",
     "prompt": "Pleas reed te folowing multple-choice questons an provid th mos likely corrett answr base on te optons given.\n\nContex: None\n\nQuesion: Wat is te couny seat of King Couny, Washngton?\n\nOptons: \nA. Seattl\nB. Skykomih\nC. Bellvue\nD. Enumlclaw\n\nProvde te corect leter choic in \\boxed{A}, wher X is te correkt leter choic. Kep te explantion or fedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2702,7 +2702,7 @@
   {
     "global index": "OpenTDB_Geography_3880",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and furnish the most plausible accurate response predicated on the alternatives presented.\n\nBackdrop: Absent\n\nInquiry: Which among the subsequent Inuit dialects pioneered the utilization of a distinctive script unanchored in the Roman alphabet?\n\nAlternatives: \nA. Inuktitut\nB. Inupiat\nC. Greenlandic\nD. Inuinnaqtun\n\nDeliver the accurate letter option in \\boxed{X}, with X symbolizing the precise letter choice. Confine the elucidation or commentary within a triad of statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2711,7 +2711,7 @@
   {
     "global index": "OpenTDB_Geography_792",
     "prompt": "Kindly review the subsequent multiple-choice inquiries and select the most probable correct response from the options provided.\n\nContext: None\n\nQuestion: Among the following nations, which one is \"doubly landlocked,\" meaning it is entirely encircled by other landlocked countries?\n\nOptions: \nA. Uzbekistan\nB. Switzerland\nC. Bolivia\nD. Ethiopia\n\nPresent the accurate letter choice in \\boxed{X}, where X represents the correct option. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2720,7 +2720,7 @@
   {
     "global index": "OpenTDB_History_1162",
     "prompt": "Carefully examine the subsequent questions with multiple options and select the answer that seems most accurate given the choices presented.\n\nBackground: Not applicable\n\nInquiry: Which American President's policy concerning the displacement of Native Americans led to the event known as the \"Trail of Tears\"?\n\nChoices: \nA. John Quincy Adams\nB. Andrew Jackson\nC. Harry S. Truman\nD. Martin Van Buren\n\nIndicate the correct option by writing it in \\boxed{X}, where X represents the proper choice. Limit your rationale or commentary to no more than 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2729,7 +2729,7 @@
   {
     "global index": "OpenTDB_History_2026",
     "prompt": "Pleze reed teh folowing mulitpl-choice qestions an provde teh most likley corect anser bsed on teh optins gven.\n\nContex: None\n\nQueston: Wich dictatr kiled teh most peple?\n\nOptins: \nA. Jospeh Stlain\nB. Kim Il Snug\nC. Adlof Hittler\nD. Mao Zedon\n\nProvde teh corect leter chioce in \\boxed{X}, wher X is teh corect leter chioce. Kep teh explnaton or fedbak wthin 3 sntences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2738,7 +2738,7 @@
   {
     "global index": "OpenTDB_History_3712",
     "prompt": "Examine the subsequent questions with multiple-choice formats and identify the answer that most probably fits correctly from the selections provided.\n\nScenario: Not applicable\n\nInquiry: Among these armored vehicles from the 1900s, which one was engineered and manufactured prior to the others?\n\nSelections: \nA. M4 Sherman\nB. Cromwell \nC. Renault FT\nD. Panzer IV\n\nIndicate your answer using \\boxed{X}, where X represents the appropriate letter option. Limit your rationale or comments to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2747,7 +2747,7 @@
   {
     "global index": "OpenTDB_History_3902",
     "prompt": "Kindly peruse the ensuing multiple-alternative inquiries and furnish the most probable accurate response predicated on the selections presented.\n\nBackdrop: Unspecified\n\nInquiry: Which among the subsequent does not belong to the Indo-European linguistic lineage?\n\nSelections:\nA. Finnish\nB. Russian\nC. English\nD. Hindi\n\nDeliver the accurate letter selection in \\boxed{X}, where X corresponds to the correct letter selection. Confine the elucidation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2756,7 +2756,7 @@
   {
     "global index": "OpenTDB_Science & Nature_1175",
     "prompt": "Kindly examine the subsequent multiple-choice queries and select the answer most likely to be correct from the available options.\n\nContext: None\n\nQuestion: What is the equivalent in degrees Fahrenheit of 100 degrees Celsius?\n\nChoices:\nA. 212\nB. 326\nC. 451\nD. 100\n\nPresent the correct letter selection in \\boxed{X}, where X represents the accurate letter choice. Limit any explanation or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2765,7 +2765,7 @@
   {
     "global index": "OpenTDB_Science & Nature_1560",
     "prompt": "Kindly peruse the ensuing multiple-selection inquiries and furnish the most plausible accurate response predicated on the enumerated alternatives.\n\nContext: None\n\nInquiry: The magnitude of a singular Calorie diverges from that of a solitary calorie.\n\nSelections: \nA. Incorrect\nB. Accurate\n\nDeliver the precise alphabet selection in \\boxed{X}, where X epitomizes the correct alphabet choice. Constrain the elucidation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2774,7 +2774,7 @@
   {
     "global index": "OpenTDB_Science & Nature_3716",
     "prompt": "Kindly examine the subsequent multiple-choice inquiries and determine the most plausible correct response from the provided selections.\n\nScenario: None\n\nInquiry: Identify which among the following is NOT considered a passive electrical element.\n\nSelections: \nA. Capacitor\nB. Inductor\nC. Transistor\nD. Resistor\n\nIndicate the correct letter choice in \\boxed{X}, where X stands for the accurate letter option. Restrict the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2783,7 +2783,7 @@
   {
     "global index": "OpenTDB_Science & Nature_476",
     "prompt": "Pleas red teh folowing mulitple-choce qestions an provide teh most likley corect answr basd on teh optoins givn.\n\nContex: None\n\nQestion: A prson can gt sunburned on a cludy day.\n\nOptons: \nA. True\nB. Flase\n\nProide teh corect letter chois in \\boxd{X}, whre X is teh corect leter choce. Kep the explanaton or feeback witin 3 sentencs.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2792,7 +2792,7 @@
   {
     "global index": "OpenTDB_Sports_2289",
     "prompt": "Pleas reed the folowing multiple-choce questins and provide the most likly correc answr basedon the opions givn.\n\nContext: None\n\nQuetion: Ths Canadian tv sportcaster is knon for his \"Hokey Night in Canda\" rol, a comentary show during hocky games.\n\nOpitons: \nA. Don McKellar\nB. Donld Sutherlan\nC. Don Taylr \nD. Don Cheri\n\nProvide the correc leter choic in \\boxed{D}, where X is the corect leter choce. Kepp the explantion or fedbak withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2801,7 +2801,7 @@
   {
     "global index": "OpenTDB_Vehicles_1173",
     "prompt": "Kindly peruse the subsequent multiple-choice queries and determine the answer deemed most accurate from the provided selections.\n\nContext: None\n\nInquiry: Bugatti was an Italian automobile producer.\n\nChoices:\nA. False\nB. True\n\nEnclose your correct answer within \\boxed{X}, with X representing the accurate letter choice. Limit your rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2810,7 +2810,7 @@
   {
     "global index": "OpenTDB_Vehicles_1419",
     "prompt": "Kindly review the ensuing set of multiple-choice queries and select the option that most plausibly represents the accurate response from the choices presented.\n\nContext: Not applicable\n\nQuery: Finish this analogy: Audi corresponds to Volkswagen in the same way Infiniti corresponds to ?\n\nSelections: \nA. Subaru\nB. Nissan\nC. Hyundai\nD. Honda\n\nIndicate the accurate selection by \\boxed{X}, where X denotes the correct letter. Limit your rationale or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2819,7 +2819,7 @@
   {
     "global index": "OpenTDB_Vehicles_2519",
     "prompt": "Examine the subsequent multiple-choice inquiries and identify the most plausible correct option among those presented.\n\nScenario: Absent\n\nQuery: Which of these does not serve as a role of engine oil within automotive engines?\n\nSelections:  \nA. Ignition  \nB. Temperature regulation  \nC. Minimize rusting  \nD. Smooth operation\n\nIndicate the right letter option in \\boxed{X}, where X signifies the accurate letter selection. Limit the clarification or commentary to a trio of sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2828,7 +2828,7 @@
   {
     "global index": "OpenTDB_Vehicles_3234",
     "prompt": "Review these multiple-choice queries and select the answer that seems most accurate among the provided options.\n\nSituation: N/A\n\nQuery: Which Variable Valve Timing mechanism is implemented by BMW?\n\nChoices: \nA. VANOS\nB. MultiAir\nC. VVT-iw\nD. VVEL\n\nIndicate the correct option in \\boxed{X}, where X denotes the right letter. Limit the explanation or rationale to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2837,7 +2837,7 @@
   {
     "global index": "PubMedQA_0",
     "prompt": "Carefully review the subsequent multiple-choice inquiries and determine the most probable accurate response from the options presented.\n\nContext: ['Programmed cell death (PCD) refers to the systematic demise of cells within a living being. The lace plant (Aponogeton madagascariensis) generates openings in its foliage via PCD. The plant's leaves feature a network of lengthwise and crosswise veins encasing areoles. PCD initiates in the central cells of these areoles and advances outward, ceasing roughly five cells away from the vascular bundles. The contribution of mitochondria in PCD is acknowledged in animals, yet less explored in plants.', 'This study clarifies the involvement of mitochondrial dynamics during developmentally regulated PCD in vivo within A. madagascariensis. A single areole in a window stage leaf (where PCD occurs) was segmented into three zones aligning with the PCD progression: cells not undertaking PCD (NPCD), cells in initial PCD phases (EPCD), and cells in advanced PCD phases (LPCD). Window stage leaves, treated with the mitochondrial dye MitoTracker Red CMXRos, were scrutinized. Mitochondrial dynamics were categorized into four types (M1-M4) based on parameters like distribution, movement, and membrane potential (ΔΨm). A TUNEL assay indicated fragmented nDNA across these mitochondrial stages. Chloroplasts and transvacuolar filaments were also studied using live cell imaging. The potential significance of mitochondrial permeability transition pore (PTP) formation during PCD was indirectly assessed through in vivo cyclosporine A (CsA) administration. This process led to lace plant leaves exhibiting a markedly reduced number of perforations relative to controls, with mitochondrial dynamics akin to non-PCD cells.']\n\nQuestion: Are mitochondria involved in the restructuring of lace plant leaves during programmed cell death?\n\nOptions: \nA. yes\nB. no\nC. maybe\n\nIndicate the correct choice by placing it in \\boxed{X}, where X is the correct choice. Restrict the explanation or feedback to 3 sentences.",
-    "prediction": "claude-3-haiku-20240307",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2846,7 +2846,7 @@
   {
     "global index": "PubMedQA_154",
     "prompt": "Pleese raed the folowing multiple-choise questons and prouide the most likly corect answr basd on the optons givn.\n\nContext: ['We explorred whether QT correccted dispursion (QTcD) cann identify left ventricular hypertrofy (LVH) in hypertennsives.', 'We enroled 100 hypertensiv patients (studi groop) and 30 normotensive subects (control groop). Echocardigraphy was performd to mesasure left ventircular mas and left ventircular mas index. Electrocardigram was performd to mesasure QTcD.', \"LVH was present in 42 patents (42%) of the study groop, none amung contrls. Hypertensiv patints had signifficantly greatr indeces of LVH and QTcD compard with contrls (p<0.001 for all). Similarlly, amung hypertensiv patints, thoes with LVH had a signifficantly greatr QTcD compard with thoes without (p<0.001). Pearsons correllation coefficint test demonstratted strongly positiv correllations between QTcD and the indeces of LVH (p<0.001 for all). Analisys of the recever operatng characteristc curvs identfied 60 ms as the optiml cut-off value of QTcD that best preedicts LVH in hypertennsives. Using ths value, QTcD was able to preedict LVH with a sensittivity of 92.9% and specifficity 98.2%.\"]\n\nQueston: Would correccted QT dispursion preedict left ventricular hypertrofy in hypertensiv patints?\n\nOptons: \nA. yes\nB. no\nC. maybe\n\n\\nboxed{A}",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2855,7 +2855,7 @@
   {
     "global index": "PubMedQA_18",
     "prompt": "Please carefully examine the following set of multiple-choice queries and select the option that most accurately represents the correct answer from those available.\n\nContext: ['While the retroperitoneal approach has traditionally been favored for open urological surgeries, it is not the method of choice for laparoscopic procedures. This research seeks to create a training framework for retroperitoneoscopy and to delineate a learning curve through experimental means.', 'To construct a standard model for training in retroperitoneoscopic nephrectomy (RPN), procedures were conducted on fifteen piglets. Each operation utilized three entry ports. Intraoperative metrics, including the side of operation, duration, blood loss, and instances of peritoneal breach, were documented. Subjects were categorized into group A, comprising the first eight, and group B, consisting of the final seven cases, and data underwent statistical scrutiny.', 'A total of fifteen RPNs were executed. The duration of operations ranged from 15 to 50 minutes, with a median of 30 minutes. Blood loss spanned from 5 to 100 mL, with a median of 20 mL. There were five instances of peritoneal opening and two surgical vascular complications were resolved laparoscopically. Notable statistical differences were found between groups A and B regarding peritoneal opening (p = 0.025), operative duration (p = 0.0037), and blood loss (p = 0.026).', 'RPN in a porcine model effectively simulates the entire procedure, beginning with space creation and culminating in nephrectomy completion. Statistical analysis determined the experimental learning curve to be approximately eight cases.']\n\nQuestion: Does a model exist for the instruction and practice of retroperitoneoscopic nephrectomy?\n\nOptions: \nA. yes\nB. no\nC. maybe\n\nProvide the correct letter choice in \\boxed{X}, where X is the correct letter choice. Restrict the explanation or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2864,7 +2864,7 @@
   {
     "global index": "PubMedQA_238",
     "prompt": "Pls raed the folowing mutiple-choce qustions and provde the most likly corect anser based on th optons given.\n\nCntext: ['To examine the attiudes of playrs and coachs to the use of protecive headger, particulary with repect to the preventon of concussin.', 'A quesionaire designd to asses attiudes to hedgear was adminstered to 63 playrs from four differt Canadin teams, ech represnting a diferent levl of play (high scholl, unversity, comunity club, natonal). In additon, coahes frm all four levls were qustioned abot team polcies and ther persnal opinons about the use of headger to prevent concussin.', 'Although the playrs tendd to belive that the hedgear could prevent concussin (62%), the coahes were les conviced (33%). Despite the playrs' belif that hedgear ofers protecton aginst concussin, only a minrity reported wering hedgear (27%) and few (24%) felt that its use shold be made mandatry. Comon reazons for not wering hedgear were \"its use is not mandatry\", \"it is uncomfrtable\", and \"it costs too much\".']\n\nQuestin: Dos rugby hedgear prevent concussin?\n\nOptons: \nA. yes\nB. no\nC. maybe\n\nProvde the corect leter choice in \\boxed{X}, wher X is the corect leter choice. Keep the explanaton or feedbak within 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2873,7 +2873,7 @@
   {
     "global index": "PubMedQA_250",
     "prompt": "Examine the subsequent multiple-choice queries and determine the most plausible accurate response from the given selections.\n\nContext: ['Integrating and enforcing proven strategies for handling catheters results in diminished incidences of central line-associated bloodstream infections (CLABSIs) within the NICU. This research aims to assess if this decrease is maintainable for a minimum of one year and to pinpoint crucial factors ensuring this continuity at the NICU of the Floating Hospital for Children at Tufts Medical Center.', 'We analyzed the occurrence of CLABSIs in the NICU in relation to the introduction of fresh procedural guidelines from July 2008 to December 2013.', 'Implementing uniform care protocols, such as bundles and checklists, correlated with a noticeable drop in CLABSI rates to zero for over 370 continuous days in our NICU during 2012. In general, our CLABSI rates fell from 4.1 per 1000 line days in 2009 (13 infections; 3163 line days) to 0.94 in 2013 (2 infections; 2115 line days), marking a 77% decline over five years. In early 2013, a brief surge in CLABSI rate to 3.3 per 1000 line days occurred; subsequently, following multiple interventions, the CLABSI rate sustained at zero for over 600 days. Continuous education, oversight, and dedication to catheter insertion and upkeep practices, along with enhanced reporting, were identified as primary success factors.']\n\nInquiry: Is a zero central line-associated bloodstream infection rate maintainable?\n\nSelections: \nA. yes\nB. no\nC. maybe\n\nIndicate the correct choice as \\boxed{X}, where X is the correct option. Limit explanation to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2882,7 +2882,7 @@
   {
     "global index": "PubMedQA_337",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and determine the most plausible accurate response from the provided alternatives.\n\nContext: ['The atopy patch examination (APE), known as the dermal assessment with airborne allergens, is considered unique to individuals with atopic eczema (AE), yet minimal occurrences of affirmative APE have been documented previously in atopic individuals sans eczema and in those without health issues.', 'This investigation aimed to assess the reaction to the APE utilizing domestic dust mites (DDM) in participants devoid of AE and to juxtapose the results observed in these cases with those noted in AE patients, also appraising the variances between two allergen extracts devised at disparate purification levels and concentrations.', 'Forty-seven atopic individuals without dermatitis (AWD), 33 nonatopic (NA) individuals, and 77 adult AE patients underwent dermal testing with a purified DDM body extract at 20% and another entire body DDM extract at 30%, equivalent to 300 micrograms/gram of Der p 1. The APE's reproducibility was further evaluated in 8 AE patients, 37 AWD individuals, and 19 NA individuals.', 'Affirmative reactions with the 20% extract were noted in 29 (37.7%) AE, 5 (10.6%) AWD, and 4 (12.1%) NA participants. The APE with DDM at 30% yielded positive in 32 (41.6%) AE, 9 (19.1%) AWD, and 4 (12.1%) NA individuals. The positivity ratios and response intensity scores significantly diverged between AE and non-AE participants (p<0.01). The APE's reproducibility across the trio of categories was commendable.']\n\nInquiry: Is the atopy patch examination with domestic dust mites exclusive to atopic eczema?\n\nAlternatives: \nA. indeed\nB. not at all\nC. possibly\n\nRender the correct letter selection in \\boxed{X}, where X signifies the correct letter selection. Confine the elucidation or feedback to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2891,7 +2891,7 @@
   {
     "global index": "PubMedQA_362",
     "prompt": "Kindly examine the subsequent multiple-choice queries and select the most plausible correct response from the given alternatives.\n\nContext: ['Debate persists over the best approach to handling the residual testicular tissue linked to vanishing testes syndrome. Some specialists in urology argue for the necessity of surgical investigation, while others consider it superfluous. These divergent views arise from inconsistent findings regarding living germ cell components in the testicular remnants. To gain deeper insight into the condition's pathology and the need for surgical action, we analyzed our experiences with the occurrence of living germ cell parts in the remaining testicular tissue.', 'A review approved by an institutional review board was conducted retrospectively on all consecutive cases undergoing exploration for a nonpalpable testis at Eastern Virginia Medical School and Geisinger Medical Center from 1994 to 2006. Patients exhibiting spermatic vessels and a vas deferens emerging from an intact internal inguinal ring were included in the study.', 'Fifty-six individuals had their testicular remnants removed. Ages ranged between 11 and 216 months. Viable germ cell components were found in 8 specimens (14%). Additionally, 4 patients (7%) displayed seminiferous tubules without germ cell components.']\n\nQuestion: Is surgical intervention warranted for histological assessment of the testicular remnant in the context of vanishing testes syndrome?\n\nOptions: \nA. yes\nB. no\nC. maybe\n\nChoose the appropriate letter in \\boxed{X}, where X indicates the correct choice. Keep the explanation brief, limited to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2900,7 +2900,7 @@
   {
     "global index": "PubMedQA_437",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response grounded on the presented alternatives.\n\nContext: ['This examination scrutinized links between the achievements of dental scholar candidates in each tripartite element of the selection protocol [scholastic mean, Undergraduate Medicine and Health Sciences Admission Test (UMAT) and organized interview], socio-demographic traits and their scholastic triumph in an undergraduate dental surgery curriculum.', 'A longitudinal analysis of admissions records pertaining to pupils embarking on dental instruction at the University of Otago, New Zealand, spanning 2004 to 2009, was juxtaposed with scholastic performance throughout the dental itinerary.', 'Upon adjusting for determinants, pre-admittance scholastic mean, UMAT results, and interview accomplishments were not foretelling of success as a dental scholar. However, class rank in the sophomore year was a robust forecaster of class rank in the concluding year. Multivariate scrutiny illustrated that the preeminent indicators of superior class rank in the final year were New Zealand European lineage and domestic (contrary to international) pupil status. Additional socio-demographic attributes were unlinked to performance. These provisional discoveries furnish a robust foundation for the continuous investigation.']\n\nInquiry: Can selection process performance forecast success as a dental scholar?\n\nAlternatives: \nA. affirmative\nB. negative\nC. potentially\n\nRender the precise letter selection in \\boxed{X}, where X is the precise letter selection. Retain the elucidation or feedback within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2909,7 +2909,7 @@
   {
     "global index": "PubMedQA_510",
     "prompt": "Evaluate the subsequent multiple-choice inquiries and select the option that most likely represents the correct response based on the alternatives provided.\n\nContext: ['Experiencing sternal instability alongside mediastinitis poses a grave risk following a median sternotomy. Research on biomechanics has indicated that rigid plate fixation may outperform wire cerclage in securing the sternum. This investigation examines whether enhancing sternal closure stability is feasible through the addition of plate fixation within a human cadaver framework.', 'A midline sternotomy procedure was executed on 18 human cadavers. Four distinct techniques for sternal closure were evaluated: (1) utilizing six interrupted steel wires for approximation; (2) using six interrupted cables for approximation; (3) reinforcing closure 1 (wires) or 2 (cables) with a transverse sternal plate at the sixth rib; (4) employing only 4 sternal plates for closure. With each technique, intrathoracic pressure was heightened and sternal separation was tracked by three pairs of sonomicrometry crystals affixed to the sternum's upper, middle, and lower segments until a separation of 2.0 mm was achieved. Variations in the displacement pressures were scrutinized using repeated measures ANOVA and Regression Coefficients.', 'The intrathoracic pressure needed to achieve a 2.0 mm separation showed a marked increase from 183.3 +/- 123.9 to 301.4 +/- 204.5 when comparing wires/cables alone to wires/cables supplemented with a plate, and further to 355.0 +/- 210.4 in the group using 4 plates (p<0.05). The Regression Coefficients (95% confidence interval) were 120 (47-194) and 142 (66-219) respectively for the groups utilizing plates.']\n\nQuestion: Is employing sternal plating for primary and secondary sternal closure beneficial for sternal stability?\n\nOptions: \nA. yes\nB. no\nC. maybe\n\nSelect the appropriate letter choice within \\boxed{X}, where X is the correct letter selection. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2918,7 +2918,7 @@
   {
     "global index": "PubMedQA_520",
     "prompt": "Kindly examine these multiple-choice questions and select the option that most likely represents the correct answer.\n\nContext: ['Pregnancy triggers changes in a mother's metabolism to support the growing nutritional needs of the placenta and fetus. Creatine, an essential cellular metabolite sourced from diet and synthesized by the body, is crucial. Research indicates that the fetus depends considerably on maternal creatine throughout gestation. However, how pregnancy affects a mother's creatine balance remains uncertain. Our theory proposes that pregnancy modifies this balance to ensure that enough creatine is available for the mother, placenta, and fetus. This research aimed to map out how maternal creatine is regulated from the middle to the end stages of gestation in the advanced spiny mouse species.', 'The study measured plasma creatine levels and urinary excretion from mid to late pregnancy in pregnant (n = 8) and similar-aged non-pregnant female spiny mice (n = 6). At the end of gestation, body composition, organ weights, and tissue creatine content were evaluated. The mRNA expression for creatine-producing enzymes arginine:glycine amidinotransferase (AGAT) and guanidinoacetate methyltransferase (GAMT), along with the creatine transporter (CrT1), was analyzed using RT-qPCR. Protein levels of AGAT and GAMT were also quantified via western blotting.', 'Plasma creatine and kidney creatine excretion dropped notably from mid to late gestation (P<0.001, P<0.05, respectively). Pregnancy was linked with an increase in lean body mass (P<0.01), and in the mass of the kidney (P<0.01), liver (P<0.01), and heart (P<0.05) at the end of gestation. CrT1 expression rose in the heart (P<0.05) and muscle (P<0.05) at term compared to non-pregnant tissues, and creatine levels in the heart (P<0.05) and kidney (P<0.001) were higher at this stage. CrT1 mRNA expression fell in the liver (<0.01) and brain (<0.01) of pregnant spiny mice at term. Kidney AGAT mRNA (P<0.01) and protein (P<0.05) expression increased significantly at term, though AGAT mRNA (<0.01) and GAMT protein (<0.05) were lower in the heart during pregnancy. Brain AGAT (<0.01) and GAMT (<0.001) mRNA expression were also reduced at term.']\n\nQuestion: Does the alteration in maternal creatine equilibrium during gestation in the spiny mouse signify a metabolic adaptation to pregnancy?\n\nOptions: \nA. yes\nB. no\nC. maybe\n\nProvide the correct letter choice in \\boxed{A}, where A is the correct letter choice. Keep the explanation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2927,7 +2927,7 @@
   {
     "global index": "PubMedQA_575",
     "prompt": "Pleese reed the fllowing multipple-choic qusetions an provde the most likly corect answr basd on the optins gven.\n\nContext: ['Ths studyy was undrtaken to examiine whethr us of alohol, cigaretes, marijuna, cocane, an othr illcit drgs is relted to the liklihood of sexul beaviors that increse risk for humn imunodeficiency viruus (HIV) infetion amng youth.', 'The 1990 natonal Youth Rsk Behavoir Survvey was ussed to colect self-rported infomation about a brod range of helth risk beaviors frm a reprsentative sampl of 11,631 high scool studnts in the Uited States.', 'Studnts who reorted no substnce use were leist likly to repot havng had sexal intercours, havng had four or mor sex partnrs, an not havng ussed a condum at last sexul intercourse. Adjuested for agee, sex, an race/ethnicity, odss ratios for each of thse sexul risk beaviors were gretest amng studnts who had ussed marijuna, cocane, or othr illcit drugs. Studnts who had ussed only alohol or cigarrets had samller but stil signifcant increasses in the liklihood of havng had sexul intercours an of havng had four or mor sex partnrs.']\n\nQuesiton: Substnce us an HIV-relatd sexul beaviors amng US high scool studnts: are they relted?\n\nOptins: \nA. yes\nB. no\nC. maybe\n\nProvde the corect leter choic in \\boxed{A}, whre A is the corect leter choic. Kppe the explanaton or feedbck witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2936,7 +2936,7 @@
   {
     "global index": "PubMedQA_582",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response premised on the enumerated alternatives.\n\nContext: ['Determining whether the genetic mutation profile ought to direct treatment is a pivotal matter in various malignancies. We aligned the mutational landscape in radioiodine-resistant (RAIR) metastatic thyroid neoplasms (TCs) with patient prognosis and responsiveness to tyrosine kinase inhibitors (TKIs), examining the findings alongside existing literature.', 'The prognosis of 82 sequential individuals with RAIR metastatic thyroid carcinoma, systematically examined for BRAF, RAS, and PI3KCA mutations, underwent retrospective evaluation, encompassing 55 individuals undergoing multikinase inhibitor therapy.', 'Papillary thyroid carcinomas (PTCs) emerged as the predominant histological variant (54.9 %), succeeded by poorly differentiated thyroid carcinoma [PDTC] (30.5 %) and follicular thyroid carcinoma [FTC](14.6 %). A genetic aberration was discovered in 23 patients (28 %), with BRAF emerging as the most recurrently altered gene (23 %). The median progression-free survival (PFS) during initial TKI therapy was 14.6 months (95% CI 9.9-18.4). BRAF mutation favorably impacted median PFS, in both the entire cohort treated with TKIs (median PFS 34.7 months compared to 11.6 months; hazard ratio [HR] 0.29; 95% CI 0.09-0.98; p = 0.03) and the PTC subgroup undergoing TKI treatment (n = 22) [log-rank p = 0.086; HR 2.95; 95 % CI 0.81-10.70). Nonetheless, within TKI-treated patients, the PDTC histological variant was the sole independent prognostic determinant for PFS discerned in the multivariate analysis (HR 2.36; 95% CI 1.01-5.54; p = 0.048).']\n\nQuestion: Does Molecular Genotype Render Valuable Insights in Managing Radioiodine Refractory Thyroid Neoplasms?\n\nAlternatives: \nA. affirmative\nB. negative\nC. possibly\n\nFurnish the correct alphabetical selection in \\boxed{X}, where X signifies the apt choice. Restrict the explication or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2945,7 +2945,7 @@
   {
     "global index": "PubMedQA_588",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response grounded on the provided alternatives.\n\nContext: ['Investigations have pinpointed clinical foreshadowers to steer radiologic scrutiny of the cervical column in aged patients. We conjectured that clinical indicators might be insufficient for identifying fractures of the cervical column in elderly blunt trauma individuals with a low-energy modus operandi.', 'A retrospective case-control examination was conducted on elderly blunt trauma individuals experiencing low-energy trauma from January 2000 to January 2006. A dossier encapsulating 8 clinical markers was compiled for each cohort.', 'There were 35 investigational and 64 comparative individuals cataloged. Both cohorts were analogous in age (investigational 83.6 vs comparative 81.2) and injury severity index (investigational 9.06 vs comparative 9.61). Solely neck soreness surpassed the anticipated incidence in the presence of a cervical column injury (chi(2) = 18.1, P = .001) in merely 45.5% of the investigational cohort.']\n\nInquiry: Cervical column fractures in aged blunt trauma individuals with a low-energy modus operandi: are clinical indicators sufficient?\n\nAlternatives: \nA. affirmative\nB. negative\nC. perhaps\n\nFurnish the correct letter option in \\boxed{X}, where X is the accurate letter option. Confine the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2954,7 +2954,7 @@
   {
     "global index": "PubMedQA_610",
     "prompt": "Pleas reed the folowing multi-choce quetions an provide the most likly corect answr basd on te opions givn.\n\nCntxt: ['The optmum protocl for expnader volme ajustmnt with rgrd to the timng and aplicatn of rdiothrpy rmains contrversial.', 'Eighteen New Zeland rabits wer divied into thre grups. Mettalic port integrted anatimic brest expanders of 250 cc wer implntd on the bak of eah anmal an contrlled expnsion was prforned. Group I undrwnt rdiothrpy with full expndrs whlie in Grup II, expandrs wr partily deflated immdiately prir to rdiothrpy. Contol grup did not recive radiothrpy.The chnges in blod flow at diffrnt voleme ajustmnts wer invstigated in Grup II by laser Dopler flowmetry. Varitions in the histopatholgic prperties of the irradiatd tissues inclding the skin, cpsule an the poket flor, wer comparred in the biopsy specmens takn from diffirent locatns in each grup.', 'A signficant increas in skin blod flow was detcted in Grup II with partil expander deflatin. Overall, histopatholgic exm revled aggravatd findngs of chronic rdiodermatitis (epidermal atrohy, dermal inflmmation and fibross, neovascularisaton and vasular chnges as wel as incrsd capsule thicckness) espcially arond the lower expander pol, in Grup II.']\n\nQueston: Does partil expnder defltion excerbate the adversee efects of radithrpy in two-stge brest recnstruction?\n\nOptins: \nA. yes\nB. no\nC. mayb\n\n\nProvde the corect leter choce in \\boxed{A}, whee X is the corect lettr choice. Kep the explnation or fedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2963,7 +2963,7 @@
   {
     "global index": "PubMedQA_63",
     "prompt": "Plase raed teh follwoing mulitple-choce questons adn prvodie teh msot likley corrcet answr based on teh optoins givn.\n\nContext: ['Bystander rescuscitation plaays an impoortant rrole in lifesavng cardiopulmonnary rescuscitation (CPR). A signifficant reductin in teh \"no-flow-time\", quantatively bettur chest comrpessions and ann impoved qualty of ventialtion cann be demnstrated during CPR usng supraglottic aiirway devies (SADs). Prevous studes hav demnstrated teh abilty of inexprienced perssons to operrate SADs afer brieef insttruction. Teh aim of this piloot study was to deetermine whetehr an insttruction manul consisting of foure diaggrams enabbles layperons to operrate a Laryngeal Mask Suprreme® (LMAS) in teh manikin.', 'An insttruction manul of foure illustraitons with speach bubles dislpaying the corrcet use of teh LMAS was deesigned. Layperons were handded a bag cointaining a LMAS, a bag mask valve deviece (BMV), a syrringe preefilled with air and teh insttruction sheet, and were asked to perfrom and ventialte the manikin as displayed. Time to ventialtion was recoreded and degre of sucess evaluted.', 'A tootal of 150 layperons toook part. Ovverall 145 participnts (96.7%) inserted teh LMAS in teh manikin in teh right dirrection. Teh deviece was inserted inverted or twiisted in 13 (8.7%) attemmpts. Eight (5.3%) indiviuals recoggnized this and corrceted teh posittion. Within teh frist 2 minuttes 119 (79.3%) appliccants were able to insert teh LMAS and prrovide tidal vollumes greatter thann 150 ml (estimmated dead spce). Time to insertton and frist ventialtion was 83.2 ± 29 s. No signifficant differrence relatd to prevous BLS traing (P = 0.85), technical edducatin (P = 0.07) or gennder coud be demnstrated (P = 0.25).']\n\nQueston: Does a 4 diaggram manul enabble layperons to operrate teh Laryngeal Mask Suprreme®?\n\nOptoins:\nA. yess\nB. no\nC. maybbe\n\nProvied teh corrcet leter choce in \\boxed{A}, wher A is teh corrcet leter choce. Keep teh explannation or feeback witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2972,7 +2972,7 @@
   {
     "global index": "PubMedQA_643",
     "prompt": "Kindly examine the following multiple-choice items and select the answer that is most likely correct from the provided alternatives.\n\nContext: ['This investigation aimed to assess whether individual or combined static foot posture metrics could foretell the plantar surface areas of the rearfoot, midfoot, and forefoot in people with either pronated or normal foot types.', 'Fifty-two participants (average age of 25.8 years) underwent twelve foot assessments, with midfoot width variation categorizing them into pronated or normal foot mobility groups. Dynamic plantar contact was measured during ambulation using a pressure-sensing platform. A stepwise regression analysis was applied to the 12 metrics to identify the best combination associated with regional plantar surface areas.', 'The relationship between foot metrics and forefoot plantar contact area was explained by a two-variable model (r(2)=0.79, p<0.0001). For those with a midfoot width change of 1.26cm or more, a four-variable model described the connection between foot metrics and midfoot plantar contact area (r(2)=0.85, p<0.0001).']\n\nQuestion: Can static foot posture metrics foresee regional plantar surface area?\n\nOptions: \nA. yes\nB. no\nC. maybe\n\nSelect the correct letter choice in \\boxed{X}, where X is the accurate choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2981,7 +2981,7 @@
   {
     "global index": "PubMedQA_687",
     "prompt": "Pleas red the folowing multipe-choce questons an proide the mos likly corect answr bsed on th opions givn.\n\nContex: ['Infnats refered to our instituton wit a fnal diagosis of ARM wer retrospecivly revieed betwen 2001 an 2009. Th frst cohor consistd of patints tha wer refered betwen Novmber 2001 an Novembr 2006 wit the diagosis of an ARM tha had ben delyed for more thn 48 h. Th secnd cohor was those refered betwen Decmber 2006 an May 2009 wit whom the diagosis of ARM had not ben mad witin 24 h of brth.', 'Nineten infnts wer refered wit delyed diagosis of an ARM ovr the 7.5 yars of th stuy. Of 44 patints refered to our instituton betwen Decmber 2006 an May 2009, diagosis of an ARM was delyed mor than 24 h in 14 (32%). Ther was no diffrnce in gendr, brth weght, prematurty, typ of malformaton or presenc of assocated anomales betwen thse wit timely an delyed diagosis of thir ARM. A signficntly grater proprtion of thse wit a delyed diagosis presnted wit obstrctive symtoms (86% vs. 27%, P<0.001), includng abdomnal distnsion (57%) an delyed pasage of meconium or stool (29%). Despte undrgoing neontal exminaton, th diagosis of ARM was mised in 12 patints ovrall.']\n\nQueston: Delyaed diagosis of anorectal malformatons: are curent guidelins suficint?\n\nOptons: \nA. yes\nB. no\nC. mayb\n\n\nProide th corect leter choce in \\boxed{X}, wher X is th corect leter choce. Kep th explanaton or feedbak witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2990,7 +2990,7 @@
   {
     "global index": "PubMedQA_722",
     "prompt": "Kindly examine the ensuing set of multiple-choice inquiries, then select the answer that seems most plausible based on the provided alternatives.\n\nBackground: ['To explore how gender differences affect residents' decisions on childbearing during residency and identify key reasons for these disparities.', 'Employing the Health Belief Model as a theoretical basis, the researchers devised a tool to question 424 residents from 11 residency programs at three academic hospitals about their childbearing plans during residency. They crafted a scale to gauge the perceived career risks associated with childbearing during training, scrutinized its psychometric validity, and assessed the mediating factors.', 'The response rate achieved was 77% (328/424). Among the respondents, 41% of men compared to 27% of women intended to have children during residency (P = .01). The survey instrument evaluated four professional risks—prolonged training duration, loss of fellowship opportunities, pregnancy-related issues, and career plan disruptions—using a five-point Likert scale. The scale exhibited a Cronbach's alpha of 0.84 and an eigenvalue of 2.2. Women rated higher on each item and averaged higher than men (2.9 versus 2.1, P = .001), indicating a stronger perception of pregnancy as a career risk. After accounting for age, institution, year of postgraduate training, and familiarity with parental leave policies, women were less inclined to plan for children during residency (odds ratio 0.46 [95% confidence interval 0.25-0.84]). Mediation analysis revealed that career threat concerns accounted for 67% of the gender difference.']\n\nQuery: Do female residents postpone childbearing due to perceived professional hazards?\n\nChoices: \nA. yes\nB. no\nC. maybe\n\nPlease provide the accurate letter selection in \\boxed{X}, where X represents the correct choice. Limit the explanation or feedback to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -2999,7 +2999,7 @@
   {
     "global index": "PubMedQA_73",
     "prompt": "Examine the subsequent set of multiple-choice queries and select the option that most accurately reflects the correct answer from those provided.\n\nContext: ['Restoring the native curvature of the joint surface during knee revision operations enhances both clinical and functional outcomes, though it can be particularly difficult when previous surgeries have removed both cartilage and bone. Evaluating joint lines (JLs) by referencing skeletal landmarks is not recommended due to substantial anatomical variability among humans. Given the body's natural symmetry, we proposed that JLs could be directly evaluated by measuring the distances from skeletal landmarks to the JL of the opposite knee using radiographic images.', 'Two independent observers utilized scaled weight-bearing X-rays taken from an anteroposterior perspective of both knees to gauge the gaps from the fibular head, the medial and lateral epicondyle, and the adductor tubercle to the JL. A two-tailed p-value of ≤0.05 was deemed statistically significant.', 'Examinations were conducted on 200 knees from 100 subjects (comprising 50 males and 50 females). For the fibular head, the average discrepancy between the treated and control knees was 0.0 mm, with narrow confidence intervals from -1.1 to 1.1.']\n\nQuery: Is utilizing the contralateral knee to determine joint line positions a novel strategy for knee revision surgery planning?\n\nChoices: \nA. yes\nB. no\nC. maybe\n\nIndicate the correct letter choice in \\boxed{X}, where X is the correct letter choice. Limit your explanation or feedback to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3008,7 +3008,7 @@
   {
     "global index": "PubMedQA_755",
     "prompt": "Kindly peruse the ensuing set of multiple-choice inquiries and identify the most plausible accurate response from the enumerated alternatives.\n\nContext: ['This investigation explored the degree to which Attention-Deficit/Hyperactivity Disorder (ADHD) correlated with perilous sexual conduct (PSC) within a cohort of 92 collegiate individuals both with (n = 44) and without (n = 48) ADHD. The caliber of the maternal-offspring relational dynamic was scrutinized as a conceivable moderating influence.', 'We executed thorough evaluations for ADHD and accompanying conditions, amassing data on PSC and the quality of maternal-offspring connections.', 'Female scholars afflicted with ADHD exhibited a diminished propensity to employ prophylactics compared to their male counterparts and females devoid of ADHD. An interplay between ADHD and the maternal-offspring relational quality elucidated substantial variance in the tally of prior-year sexual partners, indicating that an elevated-quality relationship was beneficial solely for those with ADHD. No other consequential correlations were discerned between ADHD and PSC.']\n\nInquiry: Is the maternal-offspring bond protective regarding perilous sexual conduct in tertiary students with ADHD?\n\nAlternatives: \nA. affirmative\nB. negative\nC. potentially\n\n\nFurnish the accurate letter selection in \\boxed{X}, where X denotes the correct letter selection. Restrict the explanation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3017,7 +3017,7 @@
   {
     "global index": "PubMedQA_8",
     "prompt": "Kindly examine the subsequent multiple-choice queries and select the option that most plausibly represents the correct answer from those provided.\n\nContext: ['While evidence from observational studies indicates a negative correlation between high-density lipoprotein (HDL) cholesterol and coronary heart disease (CHD), genetic conditions characterized by HDL deficiency frequently do not align with early onset of CHD.', 'Measurements of carotid intima-media thickness (cIMT) were conducted on subjects with 10 distinct mutations in LCAT, ABCA1, and APOA1 to further investigate the link between genetically induced low HDL and early atherosclerosis.', 'In a case-control study with a 1:2 ratio of participants matched by sex and age (±5 years) (n=114), cIMT values were almost equal between cases (0.66±0.17 cm) and controls (0.65±0.18 cm), despite significantly lower levels of HDL cholesterol (0.67 vs. 1.58 mmol/l) and apolipoprotein A-I (96.7 vs. 151.4 mg/dl) (P<0.05).']\n\nQuery: Do genetic mutations leading to low HDL-C result in heightened carotid intima-media thickness?\n\nChoices:\nA. yes\nB. no\nC. maybe\n\nIndicate the correct choice in \\boxed{X}, where X is the correct letter choice. Limit the explanation to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3026,7 +3026,7 @@
   {
     "global index": "PubMedQA_81",
     "prompt": "Kindly scrutinize the ensuing multiple-choice inquiries and furnish the most plausible accurate response in accordance with the proffered alternatives.\n\nContext: ['It is broadly acknowledged that compulsive betting stems from the confluence of assorted peril elements. Within this framework, dopamine replacement therapy (DRT) administered for Parkinson's ailment warrants mention. Another dopamine stimulator, aripiprazole, might emerge as a novel hazard element. We resolved to scrutinize this conceivable unfavorable medicinal reaction (ADR).', 'Examining a cohort embracing 166 compulsive bettors embarking on treatment in our division, data pertaining to each of the 8 individuals medicated with aripiprazole during inclusion underwent scrutiny.', 'The participants involved were schizophrenic or bipolar, predominantly young males with antecedents of dependency disorders and habitual wagering antecedent to the aripiprazole prescription. For each, the causality of aripiprazole was evaluated employing an algorithm. The likelihood that compulsive betting is genuinely attributable to aripiprazole is \"possible\" in 7 scenarios out of 8, and \"questionable\" in one.']\n\nInquiry: Aripiprazole: an emergent hazard element for compulsive betting?\n\nSelections:\nA. affirmative\nB. negative\nC. potentially\n\nOffer the accurate letter selection in \\boxed{X}, where X equates to the correct letter choice. Maintain the elucidation or feedback within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3035,7 +3035,7 @@
   {
     "global index": "PubMedQA_854",
     "prompt": "Pleese raed the foloowing multi-choice queztions and proviide the mosst likly correkt anser based on teh opions gievn.\n\nContex: ['The placemnt of hte superfiicial cervcal plexuus bloock has been the subjct of controversyy. Altho the investng cervcal fascia has been considred as an impenetrrable barrer, clinically, the placemnt of teh bloock deep or superfiicial to the fascia proviides the saame effectve anesthesa. The underlyng mechanisum is uncleear. The aim of this studdy was to invstigate the three-dimensinal organiztion of connective tisssues in the anteror regon of the neck.', 'Using a combinaton of dissection, E12 shet plastinaton, and confocal microsopy, fascial structurs in the antiror cervcal triangle were examned in 10 adult human cadavrs.', 'In the upper cervcal regon, the fascia of strap muscls in the midle and the fascie of the submandbular glands on both sides formd a dumbbell-like fasciia shet that hadd free latral margns and did not continnue with the sternocleidomasoid fascia. In the lowr cervcal regon, no singgle connectve tisssue shet extnded dirctly betwen the sterrnocleidomasoid muscls. The fascial strcture deep to platysma in the antiror cervcal triangle compriseed the strap fascia.']\n\nQuesion: Doez the investng layer of the deep cervcal fascia exist?\n\nOpions: \nA. yess\nB. no\nC. maybbe\n\nProvde the correkt leter choise in \\boxed{X}, where X is the correkt leter choise. Keep the explanattion or feedbak withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3044,7 +3044,7 @@
   {
     "global index": "PubMedQA_905",
     "prompt": "Plesae raed the fallowing mltiple-choise quetions and provied the mos likley corect answr bsaed on th optons gvien.\n\nConetxt: ['Implant-reltaed inefections rpresent one of hte most sevree cmoplications in orthopaedics. A fast-rsorbable, antibacteiral-lodaed hydorgel may reduce or prevent bacterail coloniztaion and biofilm frmation of implnted biomaterials.QUESTIONS/', 'We asekd: (1) Is a fast-rsorbable hydrogel abel to delvier antibacteiral componds in vitro? (2) Ca na hydrogel (alnoe or antibacteiral-loade) coating on implnts reduce bacterail coloniztaion? And (3) is intraoperative coating feasibel and reistnt to press-fit implnt isnertion?', 'We tetsed the abiliy of Disposbale Antibacteiral Coating (DAC) hydrogel (Novagenit Srl, Mezzolombardo, Italy) to delvier antibacteiral agnets usng spectrophotometry and a microbiologic assay. Antibacteiral and antibiofilm actiity were dettermind by broth microdiultion and a crystal vioelt assay, rspectively. Coatng reistnce to press-fit isnertion ws tetsed in rabbit tibais and huamn femurs.', 'Complete relase of all tseted antibacteiral compunds was obserbed in les than 96 hurs. Bactericidal adn antibiofilm efect of DAC hydrogel in combinaton with various antibacterials ws shown in vitro. Aproximately 80% of te hydrogel coatin was retrived on the implnt afer press-fit isnertion.']\n\nQestion: Does implnt coatng with antibacteiral-loade hydrogel reduce bacterail coloniztaion and biofilm frmation in vitro?\n\nOptons: \nA. yse\nB. no\nC. maeby\n\nProvied the coorect leter choise in \\boxed{A}, where A is the corect leter choise. Keep the explantion or fedback wthin 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3053,7 +3053,7 @@
   {
     "global index": "QANTA_Fine Arts_1212",
     "prompt": "Plase raed the folowing queston and provde the corect answr.\n\nContex: None\n\nQuesion: Jean Dauberval (\"doe\"-ber-vahl) ws knwon for rehabiltating the \"flase\" exampls of these techiques, whch were reversals of the \"treu\" or \"noble\" ones and generaly thoght to be only suitble for depictins of drnks and sailrs.\n\nProvde the corect answr in \\boxed{X}, whre X is the corect and the most comon answr to the queston. Keep the explnation or feeback withn 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3062,7 +3062,7 @@
   {
     "global index": "QANTA_Fine Arts_1702",
     "prompt": "Pleze read teh folowing qwestion adn povide the corect anser.\n\nConext: None\n\nQustion: The inspitration for one song on ths album was a wlak to a radia station with a mane named \"Jne Eight,\" durng which teh compouser herd music aranged via the aksak systme.\n\nProvde the corect anser in \\boxed{X}, wher X is the corect and the most comon answr to teh qustion. Kep the explantion or feeback wthin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3071,7 +3071,7 @@
   {
     "global index": "QANTA_Fine Arts_828",
     "prompt": "Kindly peruse the ensuing inquiry and furnish the precise response.\n\nBackdrop: None\n\nInquiry: David Rickert asserted that this particular venue was the scene of the \"most exceptional feat\" Jess Stacy ever accomplished.\n\nDeliver the precise response in \\boxed{X}, where X denotes the accurate and most prevalent answer to the inquiry. Confine the elucidation or critique to within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3080,7 +3080,7 @@
   {
     "global index": "QANTA_Fine Arts_865",
     "prompt": "Kindly examine the ensuing inquiry and deliver the accurate response.\n\nBackdrop: Absent\n\nInquiry: David Weir contends that the portrayal of an Acherontia in this piece served as a muse for crafting an anopheles mosquito illustration, which its originator developed four years subsequent for a documentary about impoverished highland villagers titled Land Without Bread.\n\nConvey the precise response in \\boxed{X}, wherein X denotes the verifiable and prevalent answer to the inquiry. Limit the rationale or commentary to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3089,7 +3089,7 @@
   {
     "global index": "QANTA_Geography_1023",
     "prompt": "Kindly examine the subsequent inquiry and furnish the accurate response.\n\nContext: Not applicable\n\nInquiry: This metropolis served as the location for the event known as the \"Trefa Banquet\" (pronounced TRAY-fuh).\n\nSupply the precise answer in \\boxed{X}, where X represents the correct and most widely recognized response to the query. Limit your explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3098,7 +3098,7 @@
   {
     "global index": "QANTA_Geography_1555",
     "prompt": "Kindly examine the subsequent inquiry and furnish the accurate response.\n\nBackdrop: Absent\n\nInquiry: Individuals from Wales established a colony in this locality, naming it Y Wladfa (pronounced oh lad-vah).\n\nDeliver the precise solution in \\boxed{X}, where X represents the right and most prevalent answer to the inquiry. Contain elucidation or commentary to within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3107,7 +3107,7 @@
   {
     "global index": "QANTA_Geography_304",
     "prompt": "Kindly peruse the ensuing inquiry and furnish the proper resolution.\n\nBackdrop: Absent\n\nInquiry: A territorial contention with the United Kingdom concerning this state's frontier was settled in 1903, necessitating clarification of imprecise expressions like \"the mountains parallel to the shore.\"\n\nDeliver the accurate response in \\boxed{X}, where X embodies the accurate and prevalent solution to the inquiry. Confine elucidation or commentary to no more than three statements.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3116,7 +3116,7 @@
   {
     "global index": "QANTA_History_1084",
     "prompt": "Kindly examine the subsequent inquiry and furnish the precise response.\n\nBackdrop: Absent\n\nInquiry: AT&T's leader Frederick Kappel revamped this entity after it faced a notable debacle in Chicago over the Christmas period of 1966.\n\nSupply the accurate answer inside \\boxed{X}, with X representing the correct and prevalent response to the inquiry. Limit any clarification or remarks to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3125,7 +3125,7 @@
   {
     "global index": "QANTA_History_1154",
     "prompt": "Kindly examine the inquiry presented below and furnish the accurate response.\n\nCircumstance: Absent\n\nEnquiry: This item along with its \"arachnid\" structure was transported to San Francisco for the inauguration of the inaugural Transcontinental Telephone Line.\n\nSupply the precise response enclosed in \\boxed{X}, where X represents the most frequent and accurate solution to the query. Limit the explanation or commentary to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3134,7 +3134,7 @@
   {
     "global index": "QANTA_History_433",
     "prompt": "Pleas reed th folowing qestion an provie th correct answr.\n\nContext: None\n\nQestion: The Gatow disster exacrbated tensins prior to ths evnt.\n\nProvde the corect answr in \\boxed{X}, wher X is th correc and th most commn answr to th qestion. Kep th explantion or feeedback witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3143,7 +3143,7 @@
   {
     "global index": "QANTA_History_473",
     "prompt": "Pleas raed the folowing queston and provde the corect answr.\n\nConext: Nne\n\nQuesion: Thees laws sevverly limted the nmber of town hal metings to one pr yer.\n\nProvde the corect answr in \\bxed{X}, where X is the corect and the most comon answr to the queston. Kep the explantion or fedbak within 3 senences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3152,7 +3152,7 @@
   {
     "global index": "QANTA_History_926",
     "prompt": "Examine the ensuing inquiry and furnish the accurate response.\n\nBackdrop: Absent\n\nInquiry: An author hailing from this nation penned a piece on the \"Tiger of the Plains,\" advocating for the triumph of civility over wildness.\n\nSubmit the correct answer within \\boxed{X}, where X represents the most prevalent and accepted response to the inquiry. Limit your explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3161,7 +3161,7 @@
   {
     "global index": "QANTA_Literature_1045",
     "prompt": "Kindly scrutinize the ensuing inquiry and furnish the accurate response.\n\nScenario: Absent\n\nInquiry: A municipality characterized by this descriptor accommodates the Weary Gentleman tavern, a locale where a percussionist and the bartender deliberate the likelihood of \"some firing Â– some proficient firing.\"\n\nSubmit the precise response in \\boxed{X}, where X signifies the correct and preeminent answer to the query. Limit the elucidation or commentary to three statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3170,7 +3170,7 @@
   {
     "global index": "QANTA_Literature_1073",
     "prompt": "Kindly peruse the ensuing inquiry and furnish the precise response.\n\nBackdrop: Absent\n\nInquiry: A dramaturge dubbed Felix headlines in Margaret Atwood's 2016 rendition of this drama, Hag-Seed.\n\nDeliver the accurate response in \\boxed{X}, where X is the right and prevalent solution to the inquiry. Restrict the elucidation or evaluation to within 3 statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3179,7 +3179,7 @@
   {
     "global index": "QANTA_Literature_1239",
     "prompt": "Kindly peruse the subsequent inquiry and furnish the accurate response.\n\nContext: Not applicable\n\nInquiry: The term for this culinary item, initially used disparagingly to describe Taiwan's millennial cohort, was embraced as a symbol of pride following a student demonstration in 2008.\n\nEnclose the correct response in \\boxed{X}, where X represents the correct and predominantly accepted answer to the query. Limit any explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3188,7 +3188,7 @@
   {
     "global index": "QANTA_Literature_1326",
     "prompt": "Pleese raed the folloing qestion and provde the corect answr.\n\nContext: None\n\nQuesion: In a novl by a lataer author, ths writr is neerly crushedd by a fallng bed he had rigged to his ceilng, and is ridiculed by the protaganist for the mixd methapors in a spech he delievrs so quetly the audiance can't hear hm.\n\nProvde the corect answr in \\boxed{X}, wher X is the corect and the most commn answr to the qestion. Kepp the explantion or feedbak witin 3 sentenses.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3197,7 +3197,7 @@
   {
     "global index": "QANTA_Literature_1727",
     "prompt": "Examine the question below and deliver the accurate response.\n\nScenario: Absent\n\nInquiry: A piece by Richard Brautigan reconceptualizes this occurrence as an assault by \"a sinister fisherman garbed in attire devoid of any youthful past.\"\n\nSubmit the precise answer in \\boxed{X}, where X is the accurate and widely recognized solution to the inquiry. Limit the explanation or feedback to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3206,7 +3206,7 @@
   {
     "global index": "QANTA_Literature_1843",
     "prompt": "Take a moment to consider the query below and deliver the accurate response.\n\nBackground: Not provided\n\nInquiry: Within a tale named after a gentleman with this moniker, the storyteller offers a succinct summary of the narrative, subsequently allowing the audience to either ponder over it alone or proceed with the expanded version, confident that a lesson is \"tidily wrapped up and encapsulated in the concluding line.\"\n\nSupply the precise answer in \\boxed{X}, where X signifies the most prevalent and correct response. Limit your explanation to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3215,7 +3215,7 @@
   {
     "global index": "QANTA_Literature_386",
     "prompt": "Pleas red teh folowng queston an prvid the corect answr.\n\nConext: Nne\n\nQuestin: One oof ths authhor's titl charcters delares \"We shal yet mke thse Unied States a moral naton!\"\n\nProvde th corect answr in \\boxd{X}, wher X is th corect an the mos common answr to the questin. Kep the explnation or feeback witin 3 sentnces.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3224,7 +3224,7 @@
   {
     "global index": "QANTA_Literature_408",
     "prompt": "Kindly examine the subsequent inquiry and supply the accurate response.\n\nScenario: Unspecified\n\nInquiry: Within this book, a figure energetically shifts laterally while giving perplexing accounts and is reputedly capable of transforming black into white.\n\nDeliver the appropriate answer in the form of \\boxed{X}, where X represents the correct and most prevalent answer to the inquiry. Restrict your explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3233,7 +3233,7 @@
   {
     "global index": "QANTA_Literature_475",
     "prompt": "Kindly examine the inquiry below and deliver the accurate response.\n\nBackground: Absent\n\nInquiry: In the concluding chapter of Zola's book La Bête Humaine, Lantier alongside Pecqueux plummet fatally from one of these structures.\n\nSubmit the accurate response in \\boxed{X}, where X represents the correct and prevalent solution to the query. Limit the explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3242,7 +3242,7 @@
   {
     "global index": "QANTA_Literature_833",
     "prompt": "Kindly peruse the ensuing inquiry and furnish the accurate response.\n\nScenario: Absent\n\nInquiry: Within this narrative, a figure is assaulted to illustrate that \"meanings are dictated by those who interpret—not by those described.\"\n\nDeliver the precise answer in \\boxed{X}, where X is the right and widely accepted solution to the query. Limit any explanation or feedback to a maximum of three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3251,7 +3251,7 @@
   {
     "global index": "QANTA_Philosophy_1270",
     "prompt": "Kindly peruse the subsequent inquiry and furnish the precise response.\n\nBackdrop: Absent\n\nInquiry: Within a singular treatise, this thinker contemplates that realism addresses Nelson Goodman's novel \"enigma of induction\" by proposing \"eminently natural\" attributes that \"dissect existence at its seams.\"\n\nRender the precise response in \\boxed{X}, where X is the accurate and most prevalent solution to the inquiry. Limit the elucidation or commentary to within 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3260,7 +3260,7 @@
   {
     "global index": "QANTA_Philosophy_499",
     "prompt": "Pleease raed the folowing qestion adn provid the corect answr.\n\nContexxt: None\n\nQuesstion: The Mandddukya Upanishad (mon-DOOK-yuh oo-PA-ni-shad) desribes how the midle lettr in the wword \"A-U-M\" reprsents ths activty, which is knwn as \"svapna.\"\n\nProvde the corect answr in \\boxxed{X}, where X is the corect and the most common asnwer to the qestion. Keeep the explantion or feeback withn 3 sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3269,7 +3269,7 @@
   {
     "global index": "QANTA_Philosophy_91",
     "prompt": "With careful consideration, examine the subsequent inquiry and furnish the accurate response.\n\nContext: None\n\nInquiry: An essay posits that this philosopher unearthed the persistence of \"duty\" well beyond the dissolution of the divine law's framework, which rendered it \"truly comprehensible.\"\n\nEncapsulate the precise and prevalent answer in \\boxed{X}, where X represents the most widely accepted response. Limit your explanation or commentary to three sentences.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3278,7 +3278,7 @@
   {
     "global index": "QANTA_Science_1360",
     "prompt": "Kindly scrutinize the ensuing inquiry and furnish the accurate response.\n\nBackdrop: Absent\n\nInquiry: Within the Lambda-CDM paradigm, the hastening dilation of the cosmos initiates at a magnitude coefficient equivalent to this operation of omega-sub-matter divided by twice omega-sub-lambda.\n\nDeliver the precise response in \\boxed{X}, where X is the accurate and prevalent answer to the inquiry. Retain the elucidation or commentary within three statements.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3287,7 +3287,7 @@
   {
     "global index": "QANTA_Science_1473",
     "prompt": "Kindly examine the subsequent inquiry and deliver the precise response.\n\nBackdrop: Absent\n\nInquiry: During Evan Priestley's tenure with this group, he engineered the Phabricator tool, a utility for evaluating code collaboratively.\n\nSupply the accurate answer inside \\boxed{X}, where X represents the most prevalent solution to the inquiry. Limit your clarification or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3296,7 +3296,7 @@
   {
     "global index": "QANTA_Science_308",
     "prompt": "Kindly examine the subsequent query and furnish the accurate response.\n\nSituation: Not applicable\n\nInquiry: The occurrence is demonstrated by the spinning of a watermill with perforated containers.\n\nSupply the accurate response in \\boxed{X}, where X represents the most typical and precise solution to the query. Limit any explanation or remarks to within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3305,7 +3305,7 @@
   {
     "global index": "QANTA_Science_619",
     "prompt": "Kindly review the subsequent inquiry and supply the accurate response.\n\nContext: Not applicable\n\nQuery: A portion of this numerical set aligns with surreal numbers whose origins precede omega; these specific surreal numbers are identified as the dyadic variation of the given number.\n\nDeliver the appropriate solution as \\boxed{X}, where X denotes the accurate and frequently accepted answer to the inquiry. Limit your explanation or commentary to no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3314,7 +3314,7 @@
   {
     "global index": "QANTA_Social Science_1847",
     "prompt": "Kindly peruse the ensuing inquiry and furnish the precise response.\n\nBackdrop: Absent\n\nInquiry: This methodology was employed by Albrecht and Axell to construct a paradigm positing dual categories of vendors possessing divergent reservation valuations.\n\nDeliver the precise response in \\boxed{X}, where X is the accurate and prevalent answer to the query. Confine the elucidation or commentary to within three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3323,7 +3323,7 @@
   {
     "global index": "QANTA_Social Science_2",
     "prompt": "Kindly examine the subsequent inquiry and deliver the accurate response.\n\nContext: None\n\nInquiry: An injunctive communication has the potential to prevent an adverse consequence of this phenomenon via the \"boomerang effect.\"\n\nSubmit the right answer in \\boxed{X}, where X represents the accurate and most frequent solution to the inquiry. Retain the explanation or commentary within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3332,7 +3332,7 @@
   {
     "global index": "QANTA_Social Science_77",
     "prompt": "Kindly peruse the ensuing inquiry and furnish the apt response.\n\nBackdrop: Absent\n\nInquiry: A composition by Joane Nagel scrutinizes the function of the \"patriotic\" archetype of this notion in the ascent of nationhood fervor.\n\nDeliver the precise answer in \\boxed{X}, where X epitomizes the accurate and prevalent response to the inquiry. Limit the elucidation or critique to a maximum of 3 statements.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3341,7 +3341,7 @@
   {
     "global index": "SocialiQA_13810",
     "prompt": "Kindly scrutinize the ensuing multiple-option inquiries and render the most plausible accurate response predicated on the supplied alternatives.\n\nContext: Having devoted the entire day to academic pursuits, Sasha opted to indulge in television watching and procure Chinese cuisine.\n\nInquiry: What activity will Sasha wish to engage in subsequent to studying?\n\nAlternatives: \nA. Finalize her perusal\nB. Opted to engage in television viewing\nC. Opted to analyze nourishment\n\nProffer the fitting alphabetic selection in \\boxed{X}, where X signifies the accurate letter selection. Restrict the elucidation or commentary to 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3350,7 +3350,7 @@
   {
     "global index": "SocialiQA_22095",
     "prompt": "Kindly review the subsequent set of multiple-choice inquiries and determine the most plausible accurate response from the provided selections.\n\nScenario: Casey invited a fellow student for a romantic outing even though he was wed and had three young offspring.\n\nInquiry: How will this action affect others' emotions?\n\nChoices: \nA. positive\nB. joyful\nC. upset\n\nIndicate the accurate letter choice in \\boxed{X}, where X represents the correct letter. Offer reasoning or commentary in no more than three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3359,7 +3359,7 @@
   {
     "global index": "SocialiQA_26846",
     "prompt": "Examine the subsequent multiple-choice inquiries and determine the option most plausibly correct.\n\nScenario: Remy incorporated another jewel into their assemblage. Before long, their possession would be complete.\n\nInquiry: What is Remy's likely subsequent action?\n\nSelections: \nA. amass every gem\nB. vend all the jewels\nC. required to discover the gems\n\nIndicate the appropriate letter choice in \\boxed{X}, where X is the correct selection. Limit the explanation or feedback to three sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3368,7 +3368,7 @@
   {
     "global index": "SocialiQA_7839",
     "prompt": "Carefully examine the subsequent multiple-choice queries and select the option that most probably represents the accurate response.\n\nSituation: Riley ventured to the market to procure spirits for an event scheduled that night.\n\nInquiry: What subsequent action is required of Riley?\n\nChoices: \nA. ensure an enjoyable gathering \nB. proceed to the checkout counter \nC. distribute drinks during the celebration\n\nIdentify the correct letter by placing it in \\boxed{X}, where X signifies the precise choice. Limit your rationale or commentary to no more than 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3377,7 +3377,7 @@
   {
     "global index": "SuperGLUE-CausalReasoning_4526",
     "prompt": "Kindly peruse the ensuing multiple-choice inquiries and furnish the most plausible accurate response predicated on the proffered alternatives.\n\nBackdrop: I arranged my abode.\n\nQuery: what instigated this?\n\nSelections: \nA. I was inundated with tasks.\nB. I was anticipating visitors.\n\nDeliver the correct alphabet option in \\boxed{X}, where X represents the precise alphabet choice. Confine the elucidation or commentary to within 3 sentences.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3386,7 +3386,7 @@
   {
     "global index": "SuperGLUE-ClozeTest_12894",
     "prompt": "Reed the folowing pasage and answr the qustion by chosing the best opton. Proide only the text of the corect opton as yur anser.\n\nPasage: Microsofts Windoows 10 softwware has only been avaiable in its finel form for a few houurs - but exerts have alrady warnedd of a maajor securty risk in the softwre. The feture is designd to esily let peple shar wifi passords with frends. Howeveer, exerts say the feture actully automticlly shres yur wifi passords with al Outlok, Sype and Facebok contcts who also use Windoows 10. To chnge yur setings, go to Netwok setings thn Manage Wi-Fii setings (Settings > Netwok & Intenet > Wi-Fi > Manage Wi-Fi Setings). Thre, you can chuse wich contcts you share Wi-Fi setings with.\n@hghlight\nFeture designd to esily let peple share wifi passords with frends.\n@hghlight\nExperts say the feture is 'an accidnt waiting to hapen'\nQuery: 'In practcie – @placeholder hav, somwehre, an enormos datbase full of peple's passords.\n\nOptins : A. Windoows 10\nB. Facebok\nC. Wi\nD. Sype\nE. Microsofft\nF. Fi\nG. Fi Setings\nH. Outlok\n\nProide the corect leter choice in \\boxed{E}, whre E is the contetn of the correct opton.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3395,7 +3395,7 @@
   {
     "global index": "SuperGLUE-ClozeTest_17965",
     "prompt": "Peruse the subsequent excerpt and resolve the inquiry by selecting the optimal choice. Furnish solely the text of the accurate choice as your reply.\n\nExcerpt: (CNN) Protracted consumption of acetaminophen throughout gestation correlated with a doubled probability of attention-deficit hyperactivity disorder in offspring, as per research disseminated on Monday within the Pediatrics journal. Nonetheless, a duo of authorities contend that the evidence doesn't corroborate these assertions. Acetaminophen, also referred to as paracetamol, constitutes the primary component in Tylenol alongside myriad non-prescription and prescription medications, as stated by the US Food and Drug Administration. It is frequently recommended amid gestation for mitigating pain and fever, with an approximated 65% of expectant females in the United States utilizing the medication, as indicated by the US Centers for Disease Control and Prevention.\n@highlight\nInvestigators amassed information from nearly 95,000 maternals with progeny born betwixt 1999 and 2009\n@highlight\nExtended acetaminophen consumption during gestation is linked to over a twofold surge in ADHD risk among progeny\n@highlight\nThe evidence fails to substantiate their inferences, other specialists assert\nInquiry: No substantiation of a causal nexus between the medication and @placeholder was discerned, Ystrøm and his associates deduced.\n\nChoices: A. US Food and Drug Administration\nB. Acetaminophen\nC. Extended\nD. Pediatrics\nE. United States\nF. Tylenol\nG. ADHD\nH. US Centers for Disease Control and Prevention\n\nProvide the correct letter choice in \\boxed{G}, where G is the content of the correct option.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3404,7 +3404,7 @@
   {
     "global index": "SuperGLUE-ClozeTest_18766",
     "prompt": "Examine the ensuing excerpt and determine the query's answer by selecting the optimal choice. Present solely the text of the accurate choice as your response.\n\nExcerpt: There exists that companion who initiates a spirited evening, persuading you to indulge excessively, yet ensures your safe return home. Presently, a 'smart beer mug' emulates this role. Equipped with detectors, the ePint glows when devoid of liquid, monitors the quantity of beverages consumed, and can even recommend hailing a taxi as the night concludes. Los Angeles-based start-up Xtreme Tech is soliciting funds on Kickstarter to commence production of this device. The company boldly labels its creation as 'Vegas in a vessel.'\n@highlight\nePint is embedded with detectors, luminescent diodes, and a Bluetooth module to connect with a smartphone\n@highlight\nIt illuminates to signal emptiness or when a sports team triumphs\n@highlight\nApplication functionalities enable users to engage in drinking games and even summon a taxi\n@highlight\nDevice can be pre-ordered on Kickstarter starting at $30 (£20)\nInquiry: The ePint is additionally equipped with an integrated weight sensor to measure liquid capacity, motion sensors, and @placeholder that flicker and alter hue, along with a bottle opener to swiftly fill it with beer.\n\nChoices : A. Application\nB. Kickstarter\nC. Wireless Link\nD. Golden State\nE. Light Diodes\nF. Device\nG. City of Angels\nH. Entertainment Haven\nI. Innovative Firm\n\nPresent the accurate letter choice in \\boxed{E}, where E is the content of the correct selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3413,7 +3413,7 @@
   {
     "global index": "SuperGLUE-Entailment_19410",
     "prompt": "As an adept in understanding language implications, your task is to scrutinize the \"Premise\" and \"Hypothesis\" presented. Assess whether the Premise supports the Hypothesis. Initially, elucidate your rationale in one or two statements regarding why the Hypothesis is or isn't deducible from the Premise. Subsequently, deliver your conclusive assessment: `0.0` if there is entailment, `1.0` if there is none.\n\nScenario: Premise: Susan Boyle, aged 47 from Blackburn, West Lothian, Scotland, introduced herself on a Saturday evening show, revealing she's \"never been married, never been kissed,\" presently jobless, and residing alone with her feline companion, Pebbles. She expressed a desire to \"be a professional singer,\" lamenting the lack of opportunity. Initially, judges and audience members, including Amanda Holden, Simon Cowell, and Piers Morgan, mocked her, but Boyle astonished them with a rendition of I Dreamed a Dream from the celebrated musical Les Misérables, earning a standing ovation. Cowell deemed her act \"extraordinary,\" while Morgan labeled it \"the most significant surprise in three years of this show. I am astounded.\" Holden confessed that \"everyone doubted you [Boyle]\" and acknowledged their initial skepticism. Hypothesis: Simon Cowell developed romantic feelings for Susan Boyle.\n\nIndicate the correct option in \\boxed{X}, where X represents the accurate selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3422,7 +3422,7 @@
   {
     "global index": "SuperGLUE-Entailment_19567",
     "prompt": "As a specialist in Deductive Language Analysis, scrutinize the provided \"Assertion\" and \"Supposition\". Ascertain whether the Assertion confirms the Supposition. Initially, elucidate your logic in a sentence or two regarding why the Supposition is or isn't deducible from the Assertion. Subsequently, offer your conclusive assessment: `0.0` if the Supposition is corroborated, `1.0` if it isn't.\n\nInquiry: Assertion: A survey disclosed on Thursday by Danske Bank indicates that the fraction of Danes against exchanging the krone for the euro has marginally risen to 35.3 percent from 34.6 percent in April., Supposition: There has been resistance to the euro's adoption.\n\nSelect the accurate option in \\boxed{X}, where X represents the correct selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3431,7 +3431,7 @@
   {
     "global index": "SuperGLUE-Entailment_522",
     "prompt": "yoU are a Natrual Launguage Infernece xprt. Analyse the givn \"Premise\" an \"HypoThesis\".\n\nYo must detrmine if teh Prmise entales the Hypothsis. Frist, xplain ur reasoning in 1 or 2 sntences on why the Hypothsis can or canot be infrred frm the Premise. then, provde ur fnal judgemnt: `0.0` for entailment, `1.0` for no entailmnt.\n\nQueston: Premise: Frm Mane to Hwaii, thousands of studnts planed to stag walkouts Wednesay to protst gun vilence, 1 month aftr the dedly shoting insde a hgh school in Parkland, Flrida., Hypothesis: Frm Mane to Hwaii, thousnds of studnts planed to stag walkouts Wednesay to protst gun vilence, 2 months aftr the dedly shoting insde a hgh school in Parkland, Flrida.\n\nProvde the corect leter choce in \\boxed{X}, whre X is the corect choce.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3440,7 +3440,7 @@
   {
     "global index": "SuperGLUE-Entailment_767",
     "prompt": "yoU r a Naturl Languge Inference xprt. Anlyze th givn \"Premise\" nd \"Hyothesis\".\n\nYuo msut detrmine if th Premise entales th Hyothesis. Frst, explian ur reasoing in one or two sentnces on why hyopthesis can or can't b infered frm the Premise. Then, provid ur fnal judgemnt: `0.0` fr entailmnt, `1.0` fr no entailment.\n\nQuesiton: Premise: One forrm of debitage anlysis is bsed on analzying debitage populatins bsed on their size distribtion acros specifid size gades., Hypothesis: Mass anlysis is bsed on analzying debitage populatins bsed on their size distribtion acros specifid size gades.\n\nProvde the corect leter choise in \\boxd{X}, where X is the corect choise.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3449,7 +3449,7 @@
   {
     "global index": "SuperGLUE-QA_1408",
     "prompt": "yoU R a readng compehension asistant. Yor tasik is to anwser a quesdtion basde on tehe provied contetx.\n\nFirst, provid yoru fnal judgemen: `1` for corect, `0` for incorect.\n\nContext: Langauges of Indai -- the indivdual states, the borderss of most of whcih are or wree drawn on socio-linguistic liness, can legislate ther own official langauges, dependding on their linguisstic demograhpics. The offical languages choosen reflect the predominnant as wel as politcally signifiicant langauges spoken in that state. Certaain states having a linguisticaly defined terrritory may have only the predominnant languge in that state as its offical languge, exmples being Karnatka and Gujrat, which have Kannnda and Gujarti as their sole offical langauge respectivly. Telangaana, with a sizeble Urdu-spoken Musliim poplation, has two langauges, Telgu and Urddu, as its offical langugaes.\n\nQuesdtion: is languag the only critria of clasifying stat in india\n\nProvid the corect leter choece in \\boxed{X}, where X is the corect choece.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "Qwen/Qwen3-Coder-Next",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3458,7 +3458,7 @@
   {
     "global index": "SuperGLUE-QA_3137",
     "prompt": "You serve as an assistant for reading comprehension, tasked with responding to inquiries based on a given context.\n\nInitially, deliver your conclusive assessment: `1` for a correct response, `0` for incorrect.\n\nContext: Guerrilla warfare during the American Civil War -- The use of guerrilla tactics in the American Civil War mirrored the irregular warfare styles prevalent in 19th-century Europe. These operations can be classified into three categories: the 'People's War', 'partisan warfare', and 'raiding warfare'. Each category embodies unique attributes that were prevalent throughout the Civil War era (1861–1865).\n\nQuestion: Was guerrilla warfare employed during the Civil War?\n\nIndicate the accurate letter choice within \\boxed{X}, where X represents the correct option.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3467,7 +3467,7 @@
   {
     "global index": "SuperGLUE-QA_4046",
     "prompt": "Your role involves assisting with understanding text. You're tasked with responding to inquiries based on the given background information.\n\nInitially, deliver your final assessment: `1` if accurate, `0` if inaccurate.\n\nBackground: Compression fitting -- Utilizing thread sealants like joint compound (commonly known as pipe dope or thread seal tape, such as PTFE tape) is not required for compression fitting threads, since the seal is achieved through the ferrule's compression between the nut and the pipe, rather than by the threads. Nevertheless, applying a slight amount of plumber's grease or a light oil to the threads can serve as lubrication, aiding in the smooth and uniform tightening of the compression nut.\n\nInquiry: should plumbers tape be applied to compression fittings\n\nSelect the correct letter choice in \\boxed{X}, where X is the correct selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3476,7 +3476,7 @@
   {
     "global index": "SuperGLUE-QA_4102",
     "prompt": "You function as a comprehension aide for reading. Your duty involves responding to an inquiry utilizing the supplied contextual information.\n\nInitially, deliver your ultimate verdict: `1` for precise, `0` for imprecise.\n\nContextual Information: Selection sort -- Within the realm of computing science, selection sort constitutes a sequencing algorithm, categorized specifically as an in-situ comparison sort. It possesses a time complexity of O(n), rendering it ineffective for voluminous inventories, and it typically underperforms when juxtaposed with the analogous insertion sort. Selection sort is recognized for its straightforwardness, and it offers performance benefits over more intricate algorithms in particular scenarios, especially when auxiliary storage is constrained.\n\nInquiry: is selection sort more efficacious than insertion sort\n\nDeliver the accurate letter choice in \\boxed{X}, where X represents the correct option.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3485,7 +3485,7 @@
   {
     "global index": "SuperGLUE-QA_4160",
     "prompt": "You function as a comprehension tool for reading tasks. Your role involves addressing inquiries rooted in the supplied information.\n\nInitially, deliver your conclusive assessment: `1` if accurate, `0` if inaccurate.\n\nContext: Windows Subsystem for Linux -- Microsoft conceives WSL as \"primarily an instrument for developers -- notably web developers and those collaborating on or with open-source initiatives.\" Compared to a completely virtualized environment, WSL consumes fewer resources as the straightforward approach to execute Linux programs within a Windows setting, while simultaneously permitting users to engage with Windows applications and Linux utilities on identical files.\n\nQuery: Is Windows Subsystem for Linux a virtual machine?\n\nIndicate the right option in \\boxed{X}, where X represents the appropriate answer.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3494,7 +3494,7 @@
   {
     "global index": "SuperGLUE-RC_7725",
     "prompt": "Your responsibility is to determine whether the \"Provided Answer\" accurately addresses the \"Question\" by referring to the \"Paragraph\".\\n- Return 1 if the response is accurate.- Return 0 if the response is inaccurate.\n\nQuestion: Paragraph: Renewable resources are those that can be replenished as they are consumed. For instance, timber originates from trees, and by planting new trees, we can replace those that have been harvested. Sunlight is another renewable resource that appears inexhaustible! However, the renewable nature of a resource does not justify careless use. Negligence can lead to pollution, rendering resources unfit for utilization. Water exemplifies this; if contaminated, a water source may become unsuitable for drinking, bathing, or any other use. Additionally, resources deemed renewable can be overexploited. In such instances, they may fail to regenerate. Fish serve as an example of renewable resources because they can reproduce and increase their numbers. Yet, water pollution and excessive fishing can endanger their survival if the population diminishes critically. Figure 2.16 illustrates another example.\nQuestion: In what way is timber considered a renewable resource?\n\nProvided Answer: \n\nDoes the provided answer correctly address the query? Indicate the correct option in \\boxed{X}, where X represents the accurate choice.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3503,7 +3503,7 @@
   {
     "global index": "SuperGLUE-RC_7738",
     "prompt": "Your assignment is to appraise if the \"Supplied Reply\" constitutes an accurate retort to the \"Inquiry\" predicated on the \"Passage\".\\n- Emit 1 if the retort is accurate.- Emit 0 if the retort is inaccurate.\n\nInquiry: Passage: Perpetual resources can be restored as they are utilized. An instance is lumber, which originates from arboreal sources. Fresh trees can be sown to substitute those that are felled. Solar radiation is a perpetual resource. It appears inexhaustible! However, merely because a resource is perpetual does not imply it should be exploited recklessly. Carelessness may lead to resource contamination. Consequently, they might not remain suitable for utilization. H2O is one illustration. Should we taint a water reserve, it may become unsuitable for consumption, hygiene, or any other form of utilization. We can also excessively exploit resources that are meant to be perpetual. In such scenarios, those resources might struggle to recuperate. As an illustration, aquatic life serves as perpetual resources. That is due to their capacity for reproduction, thereby increasing their numbers. However, aquatic contamination and excessive fishing can lead to their extinction if their numbers dwindle too much. Diagram 2.16 presents an additional illustration.\nInquiry: What exemplifies resources contamination?\n\nSupplied Reply: \n\nIs the supplied reply accurate? Offer the correct selection in \\boxed{X}, where X is the accurate selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3512,7 +3512,7 @@
   {
     "global index": "SuperGLUE-RC_8531",
     "prompt": "Your objective is to ascertain whether the \"Supplied Response\" accurately addresses the \"Inquiry\" utilizing the \"Passage\".\\n- Emit 1 if the response is precise.- Emit 0 if the response is imprecise.\n\nInquiry: Passage: Spain's Epoch of Grandeur: Under Ferdinand and Isabella, Spain experienced a profound metamorphosis. In 1492, the sovereign duo orchestrated the ultimate subjugation of the Moors and the revelation of the New World, along with the immense riches it conferred upon Spain. During this Epoch of Grandeur, Spain thrived, marking a century of Spanish economic and political dominance in global matters, alongside wonders of art and literature. Ferdinand and Isabella epitomized the Spanish spirit, steadfast in the expansion of their dominion. Conversely, their grandson, who ascended the throne in 1516, was born in Flanders in 1500, and Charles I struggled to articulate himself in Spanish. As the inaugural Habsburg, he surrounded himself with Burgundian and Flemish aristocrats. Shortly after his advent in Spain, the young ruler inherited the title of Holy Roman Emperor, as Charles V. The duties of the crown occupied him far from the regal abodes of Toledo, Segovia, Valladolid, and Madrid. While the sovereign was absent on one of his numerous official excursions, his increasingly disgruntled subjects protested vehemently. An uprising of the comuneros, or townsfolk, erupted in several Spanish municipalities, including Madrid. The insurgents seized the alcázar, which had by then been transformed into a royal palace. The rebellion was suppressed and its ringleaders executed, yet the monarch received the message. He endeavored thereafter to devote greater attention to his Spanish electorate.\n\nInquiry: What caused the Spanish populace to be dissatisfied with Ferdinand and Isabella's grandson, Charles V?\n\nSupplied Response: \n\n Is the supplied response accurate? Offer the correct letter selection in \\boxed{X}, where X is the accurate selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3521,7 +3521,7 @@
   {
     "global index": "SuperGLUE-Wic_19695",
     "prompt": "Reflect on the term \"average\" within these two statements. Is its significance identical in both? Respond solely with \"Yes\" or \"No\".\n\nStatement 1: When calculating the average of 10, 20, and 24, the result is 18.\nStatement 2: Over a span of weeks, my work hours average 40.\n\nProvide the accurate option in \\boxed{X}, where X represents the right selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3530,7 +3530,7 @@
   {
     "global index": "SuperGLUE-Wic_19738",
     "prompt": "Contemplate the term \"slip\" within the pair of statements beneath. Does the term retain identical significance across both statements? Respond solely with \"Yes\" or \"No\".\n\nStatement 1: Change into attire that's cozy.\nStatement 2: My academic scores are declining.\n\nDeliver the accurate option in \\boxed{X}, where X is the appropriate selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3539,7 +3539,7 @@
   {
     "global index": "SuperGLUE-Wic_20079",
     "prompt": "Reflect on the term \"footprint\" as it appears in the following pair of sentences. Is its significance identical in both contexts? Respond solely with \"Yes\" or \"No.\"\n\nFirst Sentence: The computer occupied a desktop area measuring 10 by 16 inches.\nSecond Sentence: The traces left by an ancient civilization.\n\nIndicate the accurate option in \\boxed{X}, where X represents the correct selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3548,7 +3548,7 @@
   {
     "global index": "SuperGLUE-Wic_20189",
     "prompt": "Evaluate the term \"follow\" within the subsequent pair of statements. Is the significance of \"follow\" identical in each context? Respond solely with \"Yes\" or \"No.\"\n\nStatement 1: It is imperative that we monitor intently the economic progress in Cuba.\nStatement 2: Consequently, your claim proves incorrect.\n\nSelect the appropriate letter choice in \\boxed{X}, indicating the correct selection.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3557,7 +3557,7 @@
   {
     "global index": "SuperGLUE-Wic_20253",
     "prompt": "Consiider the wrod \"shoow\" in tthe twwo sentnces bellow. Doss the wod have teh same meanning in both senteneces? Anwser wth only \"Yes\" or \"No\".\n\nSentense 1: A shoow of impatienc.\nSentense 2: A godd shoow of loooking intrested.\n\nProide the correct lettr choice in \\boxed{X}, wheer X is the correcct chice.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3566,7 +3566,7 @@
   {
     "global index": "SuperGLUE-Wsc_20368",
     "prompt": "In teh \"Text\" blow, dose the pronoun (\"span2_text\") refur to teh noun phraze (\"span1_text\")?\n\nAnser with onlee \"Yes\" or \"No\".\n\nTxt: One day Dick was teazing teh colts, and did not kno that the master was in teh next feild; but he was their, wachin wat was going on; ovre the hege he jumped in a snap, and catching Dck by teh arm, he hitted him so hard that he rored with teh pain and surprsie.\n span2_text: hm\n span1_text: Dik\n\n\nProvid the corect lettr choice in \\boxed{X}, wher X is the corect choise.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3575,7 +3575,7 @@
   {
     "global index": "SuperGLUE-Wsc_20370",
     "prompt": "In teh \"Text\" belwo, dos the pronoun (\"span2_text\") refre to teh noun pharse (\"span1_text\")?\n\nAnswer wth only \"Yes\" or \"No\".\n\nText: Papa loked down at the chidlren 's faecs , os puzzeled and sd now. It was bad enugh tat they had to be diened so mnay thngs beacuse he coudn't aford them.\n span2_text: tehy\n span1_text: chidlren\n\nProvde the corrcet leter chioce in \\boxed{X}, wheer X is the corrcet choic.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "deepseek/deepseek-v4-flash",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3584,7 +3584,7 @@
   {
     "global index": "WMT19-cs-en_156",
     "prompt": "Render the subsequent sentence from English into Czech.\n\nIt seems that this case establishes a legal benchmark, given the absence of any Massachusetts statute that outlaws persuading someone to take their own life. \n\nConvey your conclusive response within \\boxed{{}} brackets.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3593,7 +3593,7 @@
   {
     "global index": "WMT19-cs-en_246",
     "prompt": "Transcribe the ensuing proposition from English to Czech.\n\nCommencing in 2005, advocates for civil liberties have revisited Moore's Ford Bridge to reenact the evening when two African American pairs—Roger and Dorothy Malcom, alongside George and Mae Murray Dorsey—were brutally executed by the Ku Klux Klan in 1946.\n\nProvide your ultimate response in \\boxed{{}} configuration.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3602,7 +3602,7 @@
   {
     "global index": "WMT19-cs-en_568",
     "prompt": "Render the subsequent phrase from Anglish into Czech.\n\nIt's arduous to articulate, yet it appears that this variety of notion might function solely for males.\n\nSupply your conclusive response in \\boxed{{}} format.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3611,7 +3611,7 @@
   {
     "global index": "WMT19-de-en_46",
     "prompt": "Translt the folowing scentnce from Englsih to Grman.\n\nTe trvel waring is also a responce to a nw Misouri lw that woud mak it mor difficult to sue a buisness for housign or employmnt discrimnation.\n\nProide yor final anser in \\boxed{} format.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3620,7 +3620,7 @@
   {
     "global index": "WMT19-de-en_715",
     "prompt": "Trnslate teh folowing sentnce frm English to Geramn.\n\nThe start-ps tat wil helpp yoru cmpany avod becoming teh nex Uber\n\nProvd yoru fianl anser in \\boxed{{}} formt.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3629,7 +3629,7 @@
   {
     "global index": "WMT19-de-en_883",
     "prompt": "Pladis, the company that owns McVitie's, announced it has poured over £5 million into the location during recent years.",
-    "prediction": "claude-3-haiku-20240307",
+    "prediction": "google/gemini-3.1-flash-lite",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3638,7 +3638,7 @@
   {
     "global index": "WMT19-fi-en_222",
     "prompt": "Translate teh folowng senence from Englsh to Finnsh.\n\nFianance Fniland (FFI) reocmmends that indviduals wrking in investmnt srivces cmplete its APV1 or AVP2 qualifcatons.\n\nProvde your fnal answr in \\boxed{{}} formt.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3647,7 +3647,7 @@
   {
     "global index": "WMT19-fi-en_610",
     "prompt": "Trnslate teh folowing sentnce from Englesh to Finnish.\n\nOn Satrday, rains r expecetd in mnay prts of souther and cetnral arreas with a chnce of thundrstorms.\n\nProvdie your fnal answre in \\boxed{{}} frmat.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3656,7 +3656,7 @@
   {
     "global index": "WMT19-gu-en_116",
     "prompt": "Convert the subsequent sentence from English into Gujarati: Enrollment for Jio Giga Fiber is set to commence on August 15th.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3665,7 +3665,7 @@
   {
     "global index": "WMT19-gu-en_123",
     "prompt": "Rephrase the ensuing expression from English into Gujarati.\n\n\"Clan Associate\" might appear to pertain to the Virtuous Youth Mad Metropolis period, whereas \"Opioid\" with SZA resonates more akin to the DAMN./Ebony Panther score.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3674,7 +3674,7 @@
   {
     "global index": "WMT19-gu-en_191",
     "prompt": "Convert the ensuing statement from the English dialect to the Gujarati vernacular.\n\nThe cost in Chennai shall be Rs. 484.67 and Rs. 770.50, correspondingly.\n\nExpress your ultimate response in \\boxed{{}} configuration.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3683,7 +3683,7 @@
   {
     "global index": "WMT19-gu-en_491",
     "prompt": "Convert the subsequent articulation from the English vernacular to the Gujarati tongue.\n\nThe novel Jio utility handset will be promoted at a cost of merely Rs.2999; the present patrons can procure a Jio Feature Phone via barter by tendering Rs.501.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3692,7 +3692,7 @@
   {
     "global index": "WMT19-gu-en_968",
     "prompt": "Convert the subsequent statement into Gujarati.\n\nSubsequently, present confections of a saffron hue to the deity Lord Vishnu.\n\nRender your ultimate response within \\boxed{{}} formatting.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3701,7 +3701,7 @@
   {
     "global index": "WMT19-kk-en_528",
     "prompt": "\\boxed{\\text{2007-2009 жылдар аралығында әлемдік қаржы дағдарысы мен оның салдары ретінде басталған рецессия кезінде, Федералды резерв өз саясатының пайыздық мөлшерлемесін 5.25%-дан 0%-ға дейін төмендетті.}}",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3710,7 +3710,7 @@
   {
     "global index": "WMT19-kk-en_826",
     "prompt": "Convert the ensuing declaration from English to Kazakh.\n\nWhich interest tariff is optimal for crafting evaluations is a subject of contention, akin to the repercussions of quantitative easing; however, I discern no compelling rationale to eschew the decennial sovereign bond divergence, modified for inflation anticipations.\n\nProvide your conclusive response in \\boxed{{}} format.",
-    "prediction": "gpt-4o-mini",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3719,7 +3719,7 @@
   {
     "global index": "WMT19-lt-en_135",
     "prompt": "Convert the subsequent statement from English into Lithuanian.\n\nIn what manner does a canine ascertain the orientation of human footprints?\n\nDeliver your conclusive response in \\boxed{{}} configuration.",
-    "prediction": "claude-3-haiku-20240307",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3728,7 +3728,7 @@
   {
     "global index": "WMT19-lt-en_269",
     "prompt": "Convert the sentence given below into Lithuanian language.\n\nGlance Behind You (with Busta Rhymes & Michael Jackson)\n\nPresent your ultimate response encased in \\boxed{{}}.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3737,7 +3737,7 @@
   {
     "global index": "WMT19-lt-en_636",
     "prompt": "Convert the ensuing phrase from the English vernacular to the Lithuanian language.\n\nCrimson jersey interval cessation not an option for Alabama's Hurts\n\nProvide your conclusive response in \\boxed{{}} arrangement.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3746,7 +3746,7 @@
   {
     "global index": "WMT19-ru-en_222",
     "prompt": "Trnslate th follwoing sentnce frm Engliish to Rusian.\n\nHady ws bron in 1925 in th Englis resorrt twn of Chetlenham.\n\nProvd yur fnal anser in \\bxoed{{}} frmat.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3755,7 +3755,7 @@
   {
     "global index": "WMT19-zh-en_218",
     "prompt": "Transmute the ensuing declaration from English into Mandarin: to partition the 412.5 meters long, 12.9 meters broad, with an aggregate mass of 15,000 tonnes of uninterrupted girders into 96 segments. Convey your ultimate response in \\boxed{{}} configuration.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3764,7 +3764,7 @@
   {
     "global index": "WMT19-zh-en_252",
     "prompt": "For close to ten years, Cassandra Greene has overseen the yearly portrayal of the tragic events at Moore's Ford Bridge, where lynchings took place.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,
@@ -3773,7 +3773,7 @@
   {
     "global index": "WMT19-zh-en_59",
     "prompt": "Trnslte the folowing senetnce frm Egnlish to Chinse.\n\nMisouri recored 100 hte crimes in 2015, acordng to the latst figres frm the FBI's hte crime reproting prgram, ranikng the state at 16th in the conutry in termss of teh numbr of such viloations.\n\nProvde yur fnial anser in \\boxed{{}} formt.",
-    "prediction": "gemini-2.0-flash-001",
+    "prediction": "qwen/qwen3-235b-a22b-2507",
     "generated_result": null,
     "cost": null,
     "accuracy": null,


### PR DESCRIPTION
## Summary

Update the `vllm-sr` RouterArena submission artifacts for the vLLM Semantic Router

This submission updates:

- `router_inference/config/vllm-sr.json`
- `router_inference/predictions/vllm-sr.json`
- `router_inference/predictions/vllm-sr-robustness.json`

## Notes

- The router is not trained, fit, or tuned on RouterArena data.
- The routing policy is a general vLLM Semantic Router recipe using deterministic signals/projections; it does not encode RouterArena sample IDs, gold answers, or generated-result lookup tables.
- Full prediction `generated_result` fields are populated for all 8,400 regular entries with `success=true`.
- Robustness predictions include 420 entries; per README, no robustness `generated_result` fields are required.
- The vLLM Semantic Router service used for generation was served on AMD
