### PR TITLE
Fix/reasoning token cost accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ For more details, please see our [website](https://routeworks.github.io/leaderbo
 
 | Rank | Router | Affiliation | Acc-Cost Arena | Accuracy | Cost/1K Queries | Optimal Selection | Optimal Cost | Optimal Accuracy | Latency | Robustness |
 |------|--------------------|-----------------------------|--------|----------|---------|-----------------|--------------|----------------|---------|------------|
-| 🥇 | [vLLM‑SR](https://vllm-semantic-router.com/)&nbsp;[[Code]](https://github.com/vllm-project/semantic-router)&nbsp;[[HF]](https://huggingface.co/llm-semantic-router) | 🎓&nbsp;vLLM SR Team | 75.38 | 75.97 | $0.11 | 20.12 | 24.52 | 89.87 | — | 73.10 |
-| 🥈 | [Sqwish Router](https://www.sqwish.ai/) | 👤&nbsp;[@namitha-sqwish](https://github.com/namitha-sqwish) | 75.27 | 76.40 | $0.18 | 7.41 | 25.10 | 90.47 | — | 100.00 |
-| 🥉 | [AgentForge Router]() | 👤&nbsp;[@YangY-Z](https://github.com/YangY-Z) | 74.13 | 74.72 | $0.13 | 17.84 | 52.47 | 98.68 | — | 40.48 |
-| 4 | [Nadir Router](https://github.com/NadirRouter/NadirClaw) | 🎓&nbsp;NadirRouter | 73.33 | 74.87 | $0.29 | — | — | — | — | 25.48 |
-| 5 | [Weave Router](https://workweave.ai) | 🎓&nbsp;Weave | 72.82 | 76.32 | $0.94 | — | — | — | — | 100.00 |
+| 🥇 | [Sqwish Router](https://www.sqwish.ai/) | 👤&nbsp;[@namitha-sqwish](https://github.com/namitha-sqwish) | 75.27 | 76.40 | $0.18 | 7.41 | 25.10 | 90.47 | — | 100.00 |
+| 🥈 | [AgentForge Router]() | 👤&nbsp;[@YangY-Z](https://github.com/YangY-Z) | 74.13 | 74.72 | $0.13 | 17.84 | 52.47 | 98.68 | — | 40.48 |
+| 🥉 | [Weave Router](https://workweave.ai) | 🎓&nbsp;Weave | 72.82 | 76.32 | $0.94 | — | — | — | — | 100.00 |
+| 4 | [Nadir Router](https://github.com/NadirRouter/NadirClaw) | 🎓&nbsp;NadirRouter | 72.29 | 75.01 | $0.68 | — | — | — | — | 25.48 |
+| 5 | [vLLM‑SR](https://vllm-semantic-router.com/)&nbsp;[[Code]](https://github.com/vllm-project/semantic-router)&nbsp;[[HF]](https://huggingface.co/llm-semantic-router) | 🎓&nbsp;vLLM SR Team | 72.15 | 73.19 | $0.23 | 20.77 | 17.19 | 90.00 | — | 73.10 |
 | 6 | [OrcaRouter‑Adaptive](https://www.orcarouter.ai/)&nbsp;[[Code]](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite)&nbsp;[[Paper]](https://arxiv.org/abs/2605.30736)&nbsp;[[X]](https://x.com/orcarouter) | 🎓&nbsp;[Continuum&nbsp;AI](https://www.continuum01.ai/) | 72.08 | 75.54 | $1.00 | — | — | — | — | 22.62 |
-| 7 | [Azure-Model-Router](https://ai.azure.com/catalog/models/model-router)&nbsp;[[Web]](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router) | 💼&nbsp;Microsoft | 71.87 | 72.82 | $0.22 | — | — | — | — | 71.43 |
-| 8 | [R2-Router](https://arxiv.org/abs/2602.02823/) | 🎓&nbsp;UCF | 71.60 | 71.23 | $0.06 | 24.51 | 48.70 | 99.85 | — | 45.71 |
+| 7 | [R2-Router](https://arxiv.org/abs/2602.02823/) | 🎓&nbsp;UCF | 71.60 | 71.23 | $0.06 | 24.51 | 48.70 | 99.85 | — | 45.71 |
+| 8 | [Azure-Model-Router](https://ai.azure.com/catalog/models/model-router)&nbsp;[[Web]](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-router) | 💼&nbsp;Microsoft | 70.42 | 72.94 | $0.73 | — | — | — | — | 71.43 |
 | 9 | [Auto Router]() | 👤&nbsp;[@cxf2015](https://github.com/cxf2015) | 70.05 | 70.17 | $0.12 | 37.58 | 40.02 | 86.04 | — | 49.52 |
 | 10 | [MIRT‑BERT](https://arxiv.org/pdf/2506.01048)&nbsp;[[Code]](https://github.com/Mercidaiha/IRT-Router) | 🎓&nbsp;USTC | 66.89 | 66.88 | $0.15 | 3.44 | 19.62 | 78.18 | 27.03 | 61.19 |
 | 11 | [NIRT‑BERT](https://arxiv.org/pdf/2506.01048)&nbsp;[[Code]](https://github.com/Mercidaiha/IRT-Router) | 🎓&nbsp;USTC | 66.12 | 66.34 | $0.21 | 3.83 | 14.04 | 77.88 | 10.42 | 49.29 |

--- a/llm_evaluation/evaluate_models.py
+++ b/llm_evaluation/evaluate_models.py
@@ -245,16 +245,29 @@ class ModelEvaluator:
             return 0.0
 
         # Calculate cost
-        input_tokens = token_usage.get("input_tokens", 0)
-        output_tokens = token_usage.get("output_tokens", 0)
+        input_tokens = token_usage.get("input_tokens", 0) or 0
+        output_tokens = token_usage.get("output_tokens", 0) or 0
+        total_tokens = token_usage.get("total_tokens", 0) or 0
 
         input_cost_per_million = cost_info.get("input_token_price_per_million", 0.0)
         output_cost_per_million = cost_info.get("output_token_price_per_million", 0.0)
 
+        # Reasoning ("thinking") tokens are billed by providers (e.g. xAI, OpenAI)
+        # at the completion rate but are NOT included in output_tokens. They are
+        # recoverable as the gap between total_tokens and the reported input+output
+        # tokens. Bill them at the model's output rate (or an explicit reasoning
+        # rate when configured) so reasoning-capable models are not under-charged.
+        # See issue #135.
+        reasoning_tokens = max(0, total_tokens - input_tokens - output_tokens)
+        reasoning_cost_per_million = cost_info.get(
+            "reasoning_token_price_per_million", output_cost_per_million
+        )
+
         input_cost = (input_tokens / 1_000_000) * input_cost_per_million
         output_cost = (output_tokens / 1_000_000) * output_cost_per_million
+        reasoning_cost = (reasoning_tokens / 1_000_000) * reasoning_cost_per_million
 
-        total_cost = input_cost + output_cost
+        total_cost = input_cost + output_cost + reasoning_cost
         return total_cost
 
     def determine_dataset_from_global_index(self, global_index: str) -> str:

--- a/llm_evaluation/run.py
+++ b/llm_evaluation/run.py
@@ -98,6 +98,37 @@ def compute_arena_score(cost, accuracy, beta=0.1, c_max=200, c_min=0.0044):
     return S
 
 
+def has_usable_token_usage(token_usage: Any) -> bool:
+    """Return True if token_usage reports a positive output_tokens count.
+
+    A successful, non-empty generation must report usable token usage so its cost
+    can be computed. Rows with missing/empty token_usage or output_tokens == 0
+    cannot be costed and are treated as failed inference (scored as wrong, excluded
+    from cost) rather than billed at $0. See issue #135.
+    """
+    if not isinstance(token_usage, dict):
+        return False
+    output_tokens = token_usage.get("output_tokens")
+    return (
+        isinstance(output_tokens, (int, float))
+        and not isinstance(output_tokens, bool)
+        and output_tokens > 0
+    )
+
+
+def is_valid_generation(generated_result: Any) -> bool:
+    """Return True only for a successful generation with usable token usage.
+
+    Mirrors the leaderboard's integrity rule: a generation counts toward accuracy
+    and cost only if it succeeded AND reported a positive output_tokens count.
+    """
+    return (
+        isinstance(generated_result, dict)
+        and generated_result.get("success") is True
+        and has_usable_token_usage(generated_result.get("token_usage"))
+    )
+
+
 def load_predictions_file(
     router_name: str, split: Optional[str] = None
 ) -> List[Dict[str, Any]]:
@@ -621,9 +652,13 @@ def _build_evaluation_dict(
     """
     evaluation_dict: Dict[str, Dict[str, Tuple[float, float]]] = {}
 
-    # Add router selections
+    # Add router selections. Skip generations without usable token usage: an
+    # uncostable "success" must not enter the optimal-model pool at $0, where it
+    # could be falsely chosen as the cheapest optimal model. See issue #135.
     for global_index, pred in router_selections.items():
         if not global_index:  # Skip if None
+            continue
+        if not is_valid_generation(pred.get("generated_result")):
             continue
         model = pred.get("prediction")
         accuracy = pred.get("accuracy")
@@ -638,6 +673,8 @@ def _build_evaluation_dict(
     for pred in optimality_entries:
         global_index_raw = pred.get("global index") or pred.get("global_index")
         if global_index_raw is None:
+            continue
+        if not is_valid_generation(pred.get("generated_result")):
             continue
         global_index = str(global_index_raw)
         model = pred.get("prediction")
@@ -779,6 +816,12 @@ def compute_optimality_from_predictions(
             router_cost = router_pred.get("cost")
 
             if not router_model:
+                continue
+
+            # Skip failed-inference selections (no usable token usage): they are
+            # scored as wrong and have no trustworthy cost, so they must not count
+            # toward optimality. See issue #135.
+            if not is_valid_generation(router_pred.get("generated_result")):
                 continue
 
             # Skip if accuracy or cost is None or both are 0
@@ -948,11 +991,11 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
     for prediction in regular_predictions:
         generated_result = prediction.get("generated_result")
         # Prediction files are untrusted contributor input. Require success to be
-        # exactly True (a truthy string like "False" must not pass).
-        has_valid_generation = (
-            isinstance(generated_result, dict)
-            and generated_result.get("success") is True
-        )
+        # exactly True (a truthy string like "False" must not pass) AND usable token
+        # usage (positive output_tokens). A "successful" generation that reports no
+        # token usage cannot be costed; counting it would let it ride for free, so it
+        # is treated as failed inference (scored as wrong, excluded from cost). #135
+        has_valid_generation = is_valid_generation(generated_result)
         accuracy = prediction.get("accuracy")
         # Accept accuracy only if it is a real number (reject bool, since
         # isinstance(True, int) is True, and strings that would break sum()).
@@ -967,8 +1010,10 @@ def compute_router_metrics(predictions: List[Dict[str, Any]], router_name: str) 
             accuracies.append(0.0)
             abnormal_count += 1
 
+        # Only count cost for valid generations. This excludes failed-inference rows
+        # (no usable token usage) so they cannot dilute average cost as free queries.
         cost = prediction.get("cost")
-        if cost is not None and cost > 0:
+        if has_valid_generation and cost is not None and cost > 0:
             costs.append(cost)
             valid_cost_count += 1
 

--- a/router_inference/check_config_prediction_files.py
+++ b/router_inference/check_config_prediction_files.py
@@ -452,6 +452,36 @@ def check_prediction_fields(
                         f"generated_result.success must be a boolean"
                     )
 
+                # A successful, non-empty generation must report usable token usage
+                # (a token_usage dict with output_tokens > 0). Without it the cost
+                # cannot be computed and the row would otherwise ride for free; the
+                # evaluator now treats such rows as failed inference. Flag them here
+                # so submissions are caught up front. See issue #135.
+                if (
+                    isinstance(generated_result.get("success"), bool)
+                    and generated_result.get("success") is True
+                    and isinstance(generated_result.get("generated_answer"), str)
+                    and generated_result.get("generated_answer", "").strip()
+                ):
+                    token_usage = generated_result.get("token_usage")
+                    output_tokens = (
+                        token_usage.get("output_tokens")
+                        if isinstance(token_usage, dict)
+                        else None
+                    )
+                    if not (
+                        isinstance(output_tokens, (int, float))
+                        and not isinstance(output_tokens, bool)
+                        and output_tokens > 0
+                    ):
+                        errors.append(
+                            f"Entry {i} (global_index: {pred_global_index}): "
+                            f"success is True with a non-empty generated_answer but "
+                            f"token_usage has no usable output_tokens (got "
+                            f"{output_tokens!r}). Successful generations must report "
+                            f"output_tokens > 0 so cost can be computed."
+                        )
+
     return len(errors) == 0, errors
 
 

--- a/router_inference/compare_router_accuracy.py
+++ b/router_inference/compare_router_accuracy.py
@@ -90,6 +90,7 @@ def build_complete_evaluation_dictionary() -> Dict[str, Dict[str, Tuple[float, f
                     output_tokens = token_usage.get(
                         "output_tokens", token_usage.get("completion_tokens", 0)
                     )
+                    total_tokens = token_usage.get("total_tokens", 0) or 0
 
                     if input_tokens and output_tokens:
                         input_cost_per_million = cost_data[model_name][
@@ -98,12 +99,20 @@ def build_complete_evaluation_dictionary() -> Dict[str, Dict[str, Tuple[float, f
                         output_cost_per_million = cost_data[model_name][
                             "output_token_price_per_million"
                         ]
+                        # Bill reasoning tokens (total - input - output) at the
+                        # output rate, consistent with the evaluator. See issue #135.
+                        reasoning_tokens = max(
+                            0, total_tokens - input_tokens - output_tokens
+                        )
+                        reasoning_cost_per_million = cost_data[model_name].get(
+                            "reasoning_token_price_per_million", output_cost_per_million
+                        )
 
                         inference_cost = (
-                            input_tokens / 1_000_000
-                        ) * input_cost_per_million + (
-                            output_tokens / 1_000_000
-                        ) * output_cost_per_million
+                            (input_tokens / 1_000_000) * input_cost_per_million
+                            + (output_tokens / 1_000_000) * output_cost_per_million
+                            + (reasoning_tokens / 1_000_000) * reasoning_cost_per_million
+                        )
 
                 # Get accuracy (score)
                 accuracy = result["evaluation_result"]["score"]

--- a/router_inference/compare_router_accuracy.py
+++ b/router_inference/compare_router_accuracy.py
@@ -111,7 +111,8 @@ def build_complete_evaluation_dictionary() -> Dict[str, Dict[str, Tuple[float, f
                         inference_cost = (
                             (input_tokens / 1_000_000) * input_cost_per_million
                             + (output_tokens / 1_000_000) * output_cost_per_million
-                            + (reasoning_tokens / 1_000_000) * reasoning_cost_per_million
+                            + (reasoning_tokens / 1_000_000)
+                            * reasoning_cost_per_million
                         )
 
                 # Get accuracy (score)

--- a/scripts/rescore_affected.sh
+++ b/scripts/rescore_affected.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright contributors to the RouterArena project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Re-score routers affected by the issue #135 cost-accounting fix, using the real
+# evaluation pipeline (llm_evaluation/run.py) with the patched cost logic. Saves
+# each router's metrics.json to /tmp/metrics_<router>.json for leaderboard update.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ROUTERS=("$@")
+if [ ${#ROUTERS[@]} -eq 0 ]; then
+  ROUTERS=(nadir-cascade-v2 azure-model-router sqwish-router vllm-sr)
+fi
+
+for r in "${ROUTERS[@]}"; do
+  echo "=================================================================="
+  echo ">>> Re-scoring ${r} ..."
+  echo "=================================================================="
+  PYTHONPATH=. .venv/bin/python llm_evaluation/run.py "${r}" full \
+    --force --save-interval 0 --num-workers 16 --log-level WARNING
+  cp metrics.json "/tmp/metrics_${r}.json"
+  echo ">>> ${r} metrics:"
+  cat "/tmp/metrics_${r}.json"
+  echo
+done
+echo ">>> ALL DONE"

--- a/tools/audit_token_accounting.py
+++ b/tools/audit_token_accounting.py
@@ -72,22 +72,22 @@ def audit_file(path: str) -> Dict[str, Any]:
         model = r.get("prediction")
 
         if isinstance(token_usage, dict):
-            it = token_usage.get("input_tokens") or 0
-            ot = token_usage.get("output_tokens") or 0
-            tt = token_usage.get("total_tokens") or 0
-            if tt > it + ot:
+            n_in = token_usage.get("input_tokens") or 0
+            n_out = token_usage.get("output_tokens") or 0
+            n_total = token_usage.get("total_tokens") or 0
+            if n_total > n_in + n_out:
                 reasoning_rows += 1
-                reasoning_extra_tokens += tt - it - ot
+                reasoning_extra_tokens += n_total - n_in - n_out
 
         non_empty = bool(answer) and str(answer).strip() != ""
-        if gen.get("success") is True and non_empty and not _has_usable_token_usage(
-            token_usage
+        if (
+            gen.get("success") is True
+            and non_empty
+            and not _has_usable_token_usage(token_usage)
         ):
             failed_rows += 1
             failed_by_model[model] += 1
-            failed_indices.append(
-                str(r.get("global index") or r.get("global_index"))
-            )
+            failed_indices.append(str(r.get("global index") or r.get("global_index")))
 
     return {
         "router": os.path.basename(path).replace(".json", ""),
@@ -151,7 +151,9 @@ def main() -> None:
 
     failed = [s for s in summaries if s["failed_rows"]]
     if failed:
-        print("\nFailed-inference rows by model (forward these counts to the router authors):")
+        print(
+            "\nFailed-inference rows by model (forward these counts to the router authors):"
+        )
         for s in failed:
             print(f"  {s['router']}: {s['failed_by_model']}")
             if args.show_indices:

--- a/tools/audit_token_accounting.py
+++ b/tools/audit_token_accounting.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright contributors to the RouterArena project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Audit token accounting in router prediction files.
+
+Surfaces the two cost-accounting integrity issues raised in issue #135:
+
+  Problem 1 (reasoning tokens): rows where ``total_tokens`` exceeds
+    ``input_tokens + output_tokens``. The excess is billable reasoning/"thinking"
+    output that the evaluator now charges at the model's output rate. This audit
+    reports the magnitude so reviewers can sanity-check a submission's cost.
+
+  Problem 2 (failed inference): rows that report ``success: True`` with a
+    non-empty ``generated_answer`` but NO usable token usage (missing/empty
+    ``token_usage`` or ``output_tokens <= 0``). These cannot be costed and are
+    scored as wrong by the evaluator. The per-router / per-model counts here are
+    what maintainers forward to the router's authors.
+
+Usage:
+    python tools/audit_token_accounting.py                 # audit all routers
+    python tools/audit_token_accounting.py vllm-sr nadir-cascade-v2
+    python tools/audit_token_accounting.py --strict        # exit 1 if Problem 2 found
+
+Only "main" rows (for_optimality == False, the rows that feed the RouterArena
+score) are counted, matching the leaderboard.
+"""
+
+import argparse
+import glob
+import json
+import os
+from collections import Counter
+from typing import Any, Dict, List
+
+PREDICTIONS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "router_inference",
+    "predictions",
+)
+
+
+def _has_usable_token_usage(token_usage: Any) -> bool:
+    """True if token_usage reports a positive output_tokens count."""
+    if not isinstance(token_usage, dict):
+        return False
+    output_tokens = token_usage.get("output_tokens")
+    return (
+        isinstance(output_tokens, (int, float))
+        and not isinstance(output_tokens, bool)
+        and output_tokens > 0
+    )
+
+
+def audit_file(path: str) -> Dict[str, Any]:
+    """Audit a single prediction file; return a summary dict."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    rows = [r for r in data if not r.get("for_optimality", False)]
+
+    reasoning_rows = 0
+    reasoning_extra_tokens = 0
+    failed_rows = 0
+    failed_by_model: Counter = Counter()
+    failed_indices: List[str] = []
+
+    for r in rows:
+        gen = r.get("generated_result") or {}
+        token_usage = gen.get("token_usage")
+        answer = gen.get("generated_answer")
+        model = r.get("prediction")
+
+        if isinstance(token_usage, dict):
+            it = token_usage.get("input_tokens") or 0
+            ot = token_usage.get("output_tokens") or 0
+            tt = token_usage.get("total_tokens") or 0
+            if tt > it + ot:
+                reasoning_rows += 1
+                reasoning_extra_tokens += tt - it - ot
+
+        non_empty = bool(answer) and str(answer).strip() != ""
+        if gen.get("success") is True and non_empty and not _has_usable_token_usage(
+            token_usage
+        ):
+            failed_rows += 1
+            failed_by_model[model] += 1
+            failed_indices.append(
+                str(r.get("global index") or r.get("global_index"))
+            )
+
+    return {
+        "router": os.path.basename(path).replace(".json", ""),
+        "main_rows": len(rows),
+        "reasoning_rows": reasoning_rows,
+        "reasoning_extra_tokens": reasoning_extra_tokens,
+        "failed_rows": failed_rows,
+        "failed_by_model": dict(failed_by_model),
+        "failed_indices": failed_indices,
+    }
+
+
+def _resolve_paths(names: List[str]) -> List[str]:
+    if names:
+        paths = []
+        for name in names:
+            name = name.replace(".json", "")
+            path = os.path.join(PREDICTIONS_DIR, f"{name}.json")
+            if not os.path.exists(path):
+                raise SystemExit(f"Prediction file not found: {path}")
+            paths.append(path)
+        return paths
+    paths = sorted(glob.glob(os.path.join(PREDICTIONS_DIR, "*.json")))
+    return [p for p in paths if "robustness" not in os.path.basename(p)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "routers",
+        nargs="*",
+        help="Router prediction file name(s) without .json (default: all)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 if any router has failed-inference (Problem 2) rows.",
+    )
+    parser.add_argument(
+        "--show-indices",
+        action="store_true",
+        help="Print the global indices of failed-inference rows.",
+    )
+    args = parser.parse_args()
+
+    summaries = [audit_file(p) for p in _resolve_paths(args.routers)]
+
+    header = (
+        f"{'router':28} {'mainRows':>8} {'reasonRows':>10} "
+        f"{'extraTokens':>12} {'failedInfer':>11}"
+    )
+    print(header)
+    print("-" * len(header))
+    any_failed = False
+    for s in summaries:
+        any_failed = any_failed or s["failed_rows"] > 0
+        print(
+            f"{s['router']:28} {s['main_rows']:>8} {s['reasoning_rows']:>10} "
+            f"{s['reasoning_extra_tokens']:>12,} {s['failed_rows']:>11}"
+        )
+
+    failed = [s for s in summaries if s["failed_rows"]]
+    if failed:
+        print("\nFailed-inference rows by model (forward these counts to the router authors):")
+        for s in failed:
+            print(f"  {s['router']}: {s['failed_by_model']}")
+            if args.show_indices:
+                print(f"    indices: {', '.join(s['failed_indices'])}")
+
+    if args.strict and any_failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes two cost-accounting gaps in the router evaluator, both reported in #135 by @namitha-sqwish. Both are confirmed and reproduce exactly against the committed prediction files.

These are **distinct** from the empty-response fix in #118 — see Issue 2 below for how they slip through that gate.

## Issue 1 — Reasoning tokens were never billed

`ModelEvaluator.calculate_inference_cost` charged only `input_tokens + output_tokens`. Reasoning/"thinking" tokens — which providers (xAI, OpenAI, …) bill at the completion rate but report only implicitly as `total_tokens − (input + output)` — went entirely uncounted.

**Fix:** bill the recovered reasoning tokens at the model's output rate (or a `reasoning_token_price_per_million` field when configured).

Uncounted reasoning tokens across leaderboard rows:

| Router | Affected rows | Uncounted tokens |
|---|---|---|
| Azure-Model-Router | 4,803 | 8,603,765 |
| Nadir | 3,101 | 6,449,941 |
| vLLM-SR | 802 | 2,007,419 |

## Issue 2 — Successful generations with no usable token usage were free

Rows with `success: true` and a real, non-empty answer but `token_usage: {}` or `output_tokens: 0` passed the `success`-only validity gate from #118 and were therefore scored as **correct at $0 cost**.

This is the *inverse* of the #118 exploit and slips through it by construction: #118 catches *empty/failed responses*, but these rows are successful with genuine answers — they only lack reportable usage. `success is True` waves them through, the scorer counts them correct, and empty `token_usage` makes `calculate_inference_cost` return `0.0`.

**Fix:** the validity gate now also requires `output_tokens > 0`. Such rows are treated as failed inference (scored as wrong, excluded from cost) consistently across the RouterArena score, cost aggregation, and the optimality pool. This **extends** #118 rather than duplicating it.

Affected (forwarded to the router authors):
- vLLM-SR: 279 rows (278 `grok-4-1-fast-reasoning` with empty `token_usage`, 1 `gemini-3.1-flash-lite` with `output_tokens: 0`)
- Sqwish: 1 row (`deepseek-v4-flash`, `output_tokens: 0`)

## Changes

- `llm_evaluation/evaluate_models.py` — bill reasoning tokens at the output rate.
- `llm_evaluation/run.py` — `has_usable_token_usage` / `is_valid_generation` helpers; failed-inference rows excluded from accuracy credit and cost across `compute_router_metrics`, `_build_evaluation_dict`, and `compute_optimality_from_predictions`.
- `router_inference/compare_router_accuracy.py` — mirror the reasoning-token fix.
- `router_inference/check_config_prediction_files.py` — submission-time validation: a successful non-empty generation must report `output_tokens > 0`.
- `tools/audit_token_accounting.py` — audit script reporting per-router reasoning-token magnitude and failed-inference counts.
- `scripts/rescore_affected.sh` — reproducible re-score driver.
- `README.md` — leaderboard re-scored (below).

## Leaderboard impact

Only routers whose models emit reasoning tokens or zero-usage rows are re-scored (at current `model_cost.json` prices); all others are unchanged.

| Router | Arena | Accuracy | Cost/1K |
|---|---|---|---|
| vLLM-SR | 75.38 → **72.15** | 75.97 → **73.19** | $0.11 → **$0.23** |
| Nadir | 73.33 → **72.29** | 74.87 → **75.01** | $0.29 → **$0.68** |
| Azure | 71.87 → **70.42** | 72.82 → **72.94** | $0.22 → **$0.73** |

New top of board: 🥇 Sqwish · 🥈 AgentForge · 🥉 Weave · 4 Nadir · 5 vLLM-SR.

vLLM-SR's accuracy drop is driven by Issue 2: 238 of its 279 zero-usage rows had previously been scored *correct* and are now counted as wrong (the denominator is unchanged at 8,400).


## Notes for reviewers

Resolves #135.
