### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/pr-evaluation.yml
+++ b/.github/workflows/pr-evaluation.yml
@@ -28,7 +28,7 @@ jobs:
       UV_PROJECT_ENVIRONMENT: ${{ github.workspace }}/.venv
     steps:
       - name: Acknowledge /evaluate command
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -40,7 +40,7 @@ jobs:
 
       - name: Fetch PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create in-progress PR check
         id: checkrun
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const result = await github.rest.checks.create({
@@ -74,7 +74,7 @@ jobs:
             core.setOutput('id', String(result.data.id));
 
       - name: Checkout base repository (for evaluation scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.base_ref }}
           path: base
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout PR branch (for prediction file only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
           path: pr
@@ -204,7 +204,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ steps.detect.outputs.router != '' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -267,7 +267,7 @@ jobs:
 
       - name: Post evaluation results as PR comment
         if: ${{ steps.detect.outputs.router != '' && steps.evaluate.outcome == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -334,7 +334,7 @@ jobs:
 
       - name: React with success
         if: ${{ steps.detect.outputs.router != '' && steps.evaluate.outcome == 'success' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -346,7 +346,7 @@ jobs:
 
       - name: Complete PR check
         if: ${{ always() && steps.checkrun.outputs.id != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DETECTED_ROUTER: ${{ steps.detect.outputs.router }}
           DETECT_OUTCOME: ${{ steps.detect.outcome }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'  # or match your local Python version
 
@@ -31,9 +31,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout RouterArena
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -44,7 +44,7 @@ jobs:
         run: uv run python scripts/process_datasets/prep_datasets.py
 
       - name: Checkout website repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: RouteWorks/routeworks.github.io
           token: ${{ secrets.WEBSITE_SYNC_TOKEN }}


### PR DESCRIPTION
Bumps `actions/checkout@v4→v5`, `actions/setup-python@v5→v6`, `actions/github-script@v7→v8` across all three workflows to silence the `Node.js 20 is deprecated` runner warning (#176). No logic changes.

Closes #176.